### PR TITLE
Phase 2 — Moderation Adapter & Policy Layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'codex/**'
+      - 'phase/**'
   pull_request:
     branches:
       - main

--- a/app/adapters/contracts.py
+++ b/app/adapters/contracts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from app.domain.moderation import ModerationAssessment, ModerationRequest
+
 
 class InboundCollector(Protocol):
     """Contract for a platform that can collect or receive inbound comments."""
@@ -18,4 +20,22 @@ class ReplyPublisher(Protocol):
 
     async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
         """Publish a reply and return the platform reply identifier."""
+        ...
+
+
+class ModerationAdapter(Protocol):
+    """Provider-neutral async boundary for text/media moderation evidence."""
+
+    @property
+    def name(self) -> str:
+        """Stable adapter identifier suitable for audit persistence."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Stable adapter/policy version suitable for audit persistence."""
+        ...
+
+    async def assess(self, request: ModerationRequest) -> ModerationAssessment:
+        """Return normalized moderation evidence without taking external action."""
         ...

--- a/app/domain/moderation.py
+++ b/app/domain/moderation.py
@@ -1,0 +1,130 @@
+"""Platform-neutral moderation domain models and deterministic policy decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from app.domain.events import Platform
+
+
+class ModerationDisposition(StrEnum):
+    """Routing-only outcome of moderation; never an external platform action."""
+
+    ALLOW_ROUTING = "allow_routing"
+    HUMAN_REVIEW = "human_review"
+    BLOCK_ROUTING = "block_routing"
+
+
+class ModerationVerdict(StrEnum):
+    """Normalized adapter verdict before local policy is applied."""
+
+    SAFE = "safe"
+    UNSAFE = "unsafe"
+    UNCERTAIN = "uncertain"
+
+
+class ModerationSeverity(StrEnum):
+    """Normalized severity supplied by a moderation adapter."""
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    UNKNOWN = "unknown"
+
+
+class ModerationCategory(StrEnum):
+    """Provider-neutral content categories relevant to V1 moderation."""
+
+    ABUSE = "abuse"
+    HARMFUL_CONTENT = "harmful_content"
+    VIOLENCE = "violence"
+    SEXUAL_CONTENT = "sexual_content"
+    SELF_HARM = "self_harm"
+    SPAM = "spam"
+    OTHER = "other"
+
+
+class ModerationReason(StrEnum):
+    """Machine-readable reasons explaining the local moderation disposition."""
+
+    EXPLICIT_SAFE = "explicit_safe"
+    EXPLICIT_UNSAFE = "explicit_unsafe"
+    LOW_CONFIDENCE = "low_confidence"
+    UNCERTAIN_VERDICT = "uncertain_verdict"
+    TEXT_UNASSESSED = "text_unassessed"
+    MEDIA_UNASSESSED = "media_unassessed"
+    NO_ASSESSABLE_CONTENT = "no_assessable_content"
+    ADAPTER_FAILURE = "adapter_failure"
+    INVALID_ASSESSMENT = "invalid_assessment"
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationRequest:
+    """Normalized moderation input derived only from the durable event model."""
+
+    event_id: str
+    platform: Platform
+    text: str | None
+    media: dict[str, Any] | None
+
+    @property
+    def has_text(self) -> bool:
+        return bool(self.text and self.text.strip())
+
+    @property
+    def has_media(self) -> bool:
+        if not self.media:
+            return False
+        kind = self.media.get("kind")
+        return not (isinstance(kind, str) and kind.strip().lower() == "none")
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationAssessment:
+    """Normalized, provider-neutral evidence returned by a moderation adapter."""
+
+    verdict: ModerationVerdict
+    severity: ModerationSeverity
+    confidence: float
+    categories: tuple[ModerationCategory, ...] = ()
+    text_assessed: bool = False
+    media_assessed: bool = False
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("moderation confidence must be between 0 and 1")
+        if len(self.categories) != len(set(self.categories)):
+            raise ValueError("moderation categories must not contain duplicates")
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationDecision:
+    """Deterministic policy result before persistence."""
+
+    disposition: ModerationDisposition
+    reasons: tuple[ModerationReason, ...]
+
+    def __post_init__(self) -> None:
+        if not self.reasons:
+            raise ValueError("moderation decision must contain at least one reason")
+        if len(self.reasons) != len(set(self.reasons)):
+            raise ValueError("moderation reasons must not contain duplicates")
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationResult:
+    """Persisted moderation result associated with one durable inbound event."""
+
+    id: str
+    event_id: str
+    disposition: ModerationDisposition
+    reasons: tuple[ModerationReason, ...]
+    categories: tuple[ModerationCategory, ...]
+    adapter_name: str
+    adapter_version: str
+    confidence: float | None
+    created_at: datetime

--- a/app/persistence/moderation_repository.py
+++ b/app/persistence/moderation_repository.py
@@ -1,0 +1,164 @@
+"""SQLite persistence for auditable moderation results."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.moderation import (
+    ModerationCategory,
+    ModerationDecision,
+    ModerationDisposition,
+    ModerationReason,
+    ModerationResult,
+)
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+_MAX_ADAPTER_ID_LENGTH = 80
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _compact_identifier(value: str, *, field: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if len(normalized) > _MAX_ADAPTER_ID_LENGTH:
+        raise ValueError(f"{field} must be at most {_MAX_ADAPTER_ID_LENGTH} characters")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field} must be a compact identifier")
+    return normalized
+
+
+def _result_from_row(row: sqlite3.Row) -> ModerationResult:
+    raw_reasons = json.loads(str(row["reason_codes_json"]))
+    raw_categories = json.loads(str(row["categories_json"]))
+    if not isinstance(raw_reasons, list) or not isinstance(raw_categories, list):
+        raise RuntimeError("stored moderation result has invalid normalized JSON")
+    confidence = row["confidence"]
+    return ModerationResult(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        disposition=ModerationDisposition(str(row["disposition"])),
+        reasons=tuple(ModerationReason(str(value)) for value in raw_reasons),
+        categories=tuple(ModerationCategory(str(value)) for value in raw_categories),
+        adapter_name=str(row["adapter_name"]),
+        adapter_version=str(row["adapter_version"]),
+        confidence=float(confidence) if confidence is not None else None,
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+class ModerationRepository:
+    """Durable, idempotent storage boundary for Phase 2 moderation decisions."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def get_for_event(self, event_id: str) -> ModerationResult | None:
+        """Return the single persisted moderation result for an event, if present."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM moderation_results WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _result_from_row(row) if row is not None else None
+
+    def count_results(self) -> int:
+        """Return the number of persisted moderation results."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) AS count FROM moderation_results"
+            ).fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def create_for_event(
+        self,
+        *,
+        event_id: str,
+        decision: ModerationDecision,
+        categories: tuple[ModerationCategory, ...],
+        adapter_name: str,
+        adapter_version: str,
+        confidence: float | None,
+    ) -> ModerationResult:
+        """Persist one result per event and return the winner on duplicate races."""
+
+        safe_adapter_name = _compact_identifier(adapter_name, field="adapter_name")
+        safe_adapter_version = _compact_identifier(adapter_version, field="adapter_version")
+        if confidence is not None and not 0.0 <= confidence <= 1.0:
+            raise ValueError("moderation confidence must be between 0 and 1")
+
+        result_id = str(uuid4())
+        created_at = _utc_now()
+        reasons_json = json.dumps(
+            sorted(reason.value for reason in decision.reasons),
+            separators=(",", ":"),
+        )
+        categories_json = json.dumps(
+            sorted(category.value for category in categories),
+            separators=(",", ":"),
+        )
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event_exists = connection.execute(
+                "SELECT 1 FROM inbound_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if event_exists is None:
+                connection.rollback()
+                raise EventNotFound(event_id)
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO moderation_results (
+                        id, event_id, disposition, reason_codes_json, categories_json,
+                        adapter_name, adapter_version, confidence, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        result_id,
+                        event_id,
+                        decision.disposition.value,
+                        reasons_json,
+                        categories_json,
+                        safe_adapter_name,
+                        safe_adapter_version,
+                        confidence,
+                        _to_timestamp(created_at),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM moderation_results WHERE id = ?",
+                    (result_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted moderation result could not be reloaded")
+                return _result_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM moderation_results WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                return _result_from_row(row)

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -1,4 +1,4 @@
-"""SQLite schema for Gheras Social Router Phase 1."""
+"""SQLite schema for Gheras Social Router durable processing."""
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS inbound_events (
@@ -63,4 +63,22 @@ CREATE TABLE IF NOT EXISTS outbound_actions (
 
 CREATE INDEX IF NOT EXISTS idx_outbound_actions_event
 ON outbound_actions (event_id, created_at);
+
+CREATE TABLE IF NOT EXISTS moderation_results (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    disposition TEXT NOT NULL CHECK (
+        disposition IN ('allow_routing', 'human_review', 'block_routing')
+    ),
+    reason_codes_json TEXT NOT NULL,
+    categories_json TEXT NOT NULL,
+    adapter_name TEXT NOT NULL,
+    adapter_version TEXT NOT NULL,
+    confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_results_disposition
+ON moderation_results (disposition, created_at);
 """

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -1,0 +1,89 @@
+"""Async moderation orchestration over durable events and normalized adapter evidence."""
+
+from __future__ import annotations
+
+from app.adapters.contracts import ModerationAdapter
+from app.domain.moderation import (
+    ModerationAssessment,
+    ModerationCategory,
+    ModerationRequest,
+    ModerationResult,
+)
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.services.moderation_policy import ModerationPolicy
+
+_UNKNOWN_ADAPTER = "unknown-adapter"
+_UNKNOWN_VERSION = "unknown-version"
+
+
+def _safe_adapter_identity(adapter: ModerationAdapter) -> tuple[str, str]:
+    try:
+        name = adapter.name
+        version = adapter.version
+    except Exception:
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    if not name.strip() or not version.strip():
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    return name, version
+
+
+class ModerationService:
+    """Moderate one durable event exactly once at the persistence boundary."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        results: ModerationRepository,
+        adapter: ModerationAdapter,
+        policy: ModerationPolicy,
+    ) -> None:
+        self.events = events
+        self.results = results
+        self.adapter = adapter
+        self.policy = policy
+
+    async def moderate(self, event_id: str) -> ModerationResult:
+        """Return a durable routing-only moderation result for one inbound event."""
+
+        existing = self.results.get_for_event(event_id)
+        if existing is not None:
+            return existing
+
+        event = self.events.get_event(event_id)
+        request = ModerationRequest(
+            event_id=event.id,
+            platform=event.platform,
+            text=event.text,
+            media=event.media,
+        )
+        adapter_name, adapter_version = _safe_adapter_identity(self.adapter)
+
+        assessment: ModerationAssessment | None = None
+        categories: tuple[ModerationCategory, ...] = ()
+        confidence: float | None = None
+
+        try:
+            candidate = await self.adapter.assess(request)
+        except Exception:
+            decision = self.policy.adapter_failure()
+        else:
+            if not isinstance(candidate, ModerationAssessment):
+                decision = self.policy.invalid_assessment()
+            else:
+                assessment = candidate
+                categories = assessment.categories
+                confidence = assessment.confidence
+                decision = self.policy.decide(request, assessment)
+
+        return self.results.create_for_event(
+            event_id=event.id,
+            decision=decision,
+            categories=categories,
+            adapter_name=adapter_name,
+            adapter_version=adapter_version,
+            confidence=confidence,
+        )

--- a/app/services/moderation_policy.py
+++ b/app/services/moderation_policy.py
@@ -57,6 +57,20 @@ class ModerationPolicy:
                 reasons=(ModerationReason.UNCERTAIN_VERDICT,),
             )
 
+        if assessment.verdict is ModerationVerdict.SAFE:
+            if (
+                assessment.severity is not ModerationSeverity.NONE
+                or bool(assessment.categories)
+            ):
+                return ModerationDecision(
+                    disposition=ModerationDisposition.HUMAN_REVIEW,
+                    reasons=(ModerationReason.INVALID_ASSESSMENT,),
+                )
+            return ModerationDecision(
+                disposition=ModerationDisposition.ALLOW_ROUTING,
+                reasons=(ModerationReason.EXPLICIT_SAFE,),
+            )
+
         if assessment.verdict is ModerationVerdict.UNSAFE:
             if assessment.severity in {
                 ModerationSeverity.MEDIUM,
@@ -69,12 +83,6 @@ class ModerationPolicy:
             return ModerationDecision(
                 disposition=ModerationDisposition.HUMAN_REVIEW,
                 reasons=(ModerationReason.EXPLICIT_UNSAFE,),
-            )
-
-        if assessment.verdict is ModerationVerdict.SAFE:
-            return ModerationDecision(
-                disposition=ModerationDisposition.ALLOW_ROUTING,
-                reasons=(ModerationReason.EXPLICIT_SAFE,),
             )
 
         return ModerationDecision(

--- a/app/services/moderation_policy.py
+++ b/app/services/moderation_policy.py
@@ -1,0 +1,101 @@
+"""Deterministic fail-closed policy for normalized moderation evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.domain.moderation import (
+    ModerationAssessment,
+    ModerationDecision,
+    ModerationDisposition,
+    ModerationReason,
+    ModerationRequest,
+    ModerationSeverity,
+    ModerationVerdict,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationPolicy:
+    """Map normalized moderation evidence to a routing-only disposition."""
+
+    minimum_confidence: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.minimum_confidence <= 1.0:
+            raise ValueError("minimum_confidence must be between 0 and 1")
+
+    def decide(
+        self,
+        request: ModerationRequest,
+        assessment: ModerationAssessment,
+    ) -> ModerationDecision:
+        """Apply deterministic V1 moderation rules without external side effects."""
+
+        coverage_reasons: list[ModerationReason] = []
+        if request.has_text and not assessment.text_assessed:
+            coverage_reasons.append(ModerationReason.TEXT_UNASSESSED)
+        if request.has_media and not assessment.media_assessed:
+            coverage_reasons.append(ModerationReason.MEDIA_UNASSESSED)
+        if not request.has_text and not request.has_media:
+            coverage_reasons.append(ModerationReason.NO_ASSESSABLE_CONTENT)
+        if coverage_reasons:
+            return ModerationDecision(
+                disposition=ModerationDisposition.HUMAN_REVIEW,
+                reasons=tuple(coverage_reasons),
+            )
+
+        if assessment.confidence < self.minimum_confidence:
+            return ModerationDecision(
+                disposition=ModerationDisposition.HUMAN_REVIEW,
+                reasons=(ModerationReason.LOW_CONFIDENCE,),
+            )
+
+        if assessment.verdict is ModerationVerdict.UNCERTAIN:
+            return ModerationDecision(
+                disposition=ModerationDisposition.HUMAN_REVIEW,
+                reasons=(ModerationReason.UNCERTAIN_VERDICT,),
+            )
+
+        if assessment.verdict is ModerationVerdict.UNSAFE:
+            if assessment.severity in {
+                ModerationSeverity.MEDIUM,
+                ModerationSeverity.HIGH,
+            }:
+                return ModerationDecision(
+                    disposition=ModerationDisposition.BLOCK_ROUTING,
+                    reasons=(ModerationReason.EXPLICIT_UNSAFE,),
+                )
+            return ModerationDecision(
+                disposition=ModerationDisposition.HUMAN_REVIEW,
+                reasons=(ModerationReason.EXPLICIT_UNSAFE,),
+            )
+
+        if assessment.verdict is ModerationVerdict.SAFE:
+            return ModerationDecision(
+                disposition=ModerationDisposition.ALLOW_ROUTING,
+                reasons=(ModerationReason.EXPLICIT_SAFE,),
+            )
+
+        return ModerationDecision(
+            disposition=ModerationDisposition.HUMAN_REVIEW,
+            reasons=(ModerationReason.INVALID_ASSESSMENT,),
+        )
+
+    @staticmethod
+    def adapter_failure() -> ModerationDecision:
+        """Fail closed when the moderation adapter cannot provide evidence."""
+
+        return ModerationDecision(
+            disposition=ModerationDisposition.HUMAN_REVIEW,
+            reasons=(ModerationReason.ADAPTER_FAILURE,),
+        )
+
+    @staticmethod
+    def invalid_assessment() -> ModerationDecision:
+        """Fail closed when an adapter violates the normalized contract."""
+
+        return ModerationDecision(
+            disposition=ModerationDisposition.HUMAN_REVIEW,
+            reasons=(ModerationReason.INVALID_ASSESSMENT,),
+        )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,11 +37,12 @@ Each adapter normalizes platform-specific identifiers and payloads into the shar
 
 Every accepted inbound event is persisted before moderation, classification, or publishing work begins.
 
-The V1 durable core uses SQLite behind repository/service abstractions and contains three persistent concerns:
+The V1 durable core uses SQLite behind repository/service abstractions and contains persistent concerns including:
 
 - `inbound_events`: normalized accepted events and their processing state.
 - `processing_attempts`: sanitized attempt history and retry metadata.
 - `outbound_actions`: durable publish intents/results with unique idempotency keys.
+- `moderation_results`: one normalized, auditable moderation routing decision per inbound event.
 
 The uniqueness boundary for inbound work is `(platform, external_event_key)`. The uniqueness boundary for outbound work is `idempotency_key`.
 
@@ -59,6 +60,30 @@ Core processing state changes are explicit domain transitions rather than arbitr
 - `failed_terminal`
 
 Terminal states do not transition unless a future explicit recovery mechanism is introduced.
+
+### Moderation boundary
+
+Moderation happens after persist-first ingestion and before semantic classification.
+
+The moderation design is split into three responsibilities:
+
+1. A provider-neutral async `ModerationAdapter` returns normalized moderation evidence only.
+2. A deterministic local policy maps that evidence to one routing-only disposition.
+3. A durable moderation repository stores one auditable result for the inbound event.
+
+The V1 routing-only dispositions are:
+
+- `allow_routing`: moderation evidence is explicitly safe and sufficiently confident for semantic routing to continue.
+- `human_review`: evidence is missing, uncertain, low-confidence, unsupported, malformed, or the moderation adapter failed.
+- `block_routing`: sufficiently confident unsafe evidence prevents automated semantic routing.
+
+`block_routing` is not an authorization to hide, delete, report, or otherwise mutate external content. External moderation enforcement is outside this phase and requires an explicit later policy and adapter action.
+
+Text/media coverage is fail-closed. If normalized media exists but the adapter did not actually assess it, the event cannot receive `allow_routing`. Likewise, an event with no assessable text or media goes to human review rather than being guessed safe.
+
+Moderation adapter exceptions are converted to a normalized human-review result. Raw exception traces, credentials, authorization headers, provider payloads, and secret-bearing diagnostics are not persisted in `moderation_results`.
+
+The moderation result is idempotent per `event_id`. Duplicate or racing workers resolve to the same persisted result instead of creating multiple moderation rows.
 
 ### AI adapters
 
@@ -84,6 +109,7 @@ Publishing is separated from classification and response composition. A dispatch
 
 - Persist first, process later.
 - Inbound platform events are idempotent.
+- Moderation decisions are durable and idempotent per inbound event.
 - Outbound replies/actions are idempotent.
 - Accepted work and processing state survive process restarts.
 - SQLite foreign keys are enabled.
@@ -97,4 +123,6 @@ Publishing is separated from classification and response composition. A dispatch
 
 Phase 0 established configuration, the HTTP application, adapter interfaces, tests, and CI.
 
-Phase 1 builds only the durable core. It intentionally contains no real Meta, Telegram, YouTube/Google, OpenAI, or fatwa-bot calls.
+Phase 1 implements the durable core and intentionally contains no real Meta, Telegram, YouTube/Google, OpenAI, or fatwa-bot calls.
+
+Phase 2 adds the mock-first moderation domain, async adapter contract, deterministic fail-closed policy, durable moderation-result repository, and idempotent moderation service. It still performs no live external moderation call and no external hide/delete/report action.

--- a/prompts/02_PHASE2_MODERATION.md
+++ b/prompts/02_PHASE2_MODERATION.md
@@ -1,0 +1,170 @@
+# Execution Prompt — Phase 2: Moderation Adapter & Policy Layer
+
+Implement GitHub Issue #8 on branch `phase/02-moderation`, which is intentionally based on the current Phase 1 head while PR #7 remains unmerged.
+
+## Model-aware execution profile
+
+- Executor class: coding agent / repository producer.
+- Preferred executor when available: Codex-class coding agent.
+- Prompt style: explicit contracts, bounded scope, deterministic acceptance tests, fail-closed ambiguity handling.
+- Optimization claim: governed task decomposition only; no claim that model-specific benchmark superiority has been established for this task.
+- Product truth, safety rules, and acceptance criteria are invariant across model choices.
+
+## Read first
+
+- `AGENTS.md`
+- `README.md`
+- `docs/PROJECT_SPEC_AR.md`
+- `docs/ARCHITECTURE.md`
+- `prompts/01_PHASE1_DURABLE_EVENTS.md`
+- GitHub Issue #8
+
+## Objective
+
+Build the V1 moderation boundary that receives an already persisted normalized event, obtains moderation signals through a mockable async adapter, applies a deterministic policy, and stores one auditable routing-only moderation result before semantic classification.
+
+## Hard constraints
+
+1. No live Meta, Instagram, Telegram, YouTube/Google, OpenAI, or fatwa-bot calls.
+2. No API tokens or secrets are required for tests or application import/startup.
+3. Moderation must occur before semantic classification.
+4. Moderation must never generate a reply, religious answer, or fatwa.
+5. Uncertainty, adapter failure, malformed/insufficient evidence, or unsupported content must never silently become an allow decision.
+6. This phase must not hide, delete, report, or otherwise mutate external platform content.
+7. `block_routing` means only: do not continue into automated semantic routing.
+8. Domain logic must remain platform-neutral across Facebook, Instagram, Telegram, and YouTube.
+9. Store normalized/auditable moderation evidence only; do not persist raw provider payloads, credentials, authorization headers, or full exception traces.
+10. Existing Phase 1 idempotency/state-machine guarantees must not regress.
+
+## Required design
+
+### Domain
+
+Add typed moderation models with at least:
+
+- routing disposition: `allow_routing`, `human_review`, `block_routing`
+- normalized moderation categories/reason codes
+- adapter assessment/signals
+- persisted moderation result
+
+The domain contract must not contain vendor-specific response objects.
+
+### Adapter boundary
+
+Expose a mockable async moderation protocol logically equivalent to:
+
+```python
+class ModerationAdapter(Protocol):
+    async def assess(self, request: ModerationRequest) -> ModerationAssessment: ...
+```
+
+The request may contain the normalized text plus normalized media metadata already present on the durable event. It must not require raw webhook payloads.
+
+### Deterministic policy
+
+Implement a pure policy layer mapping normalized adapter signals to one routing-only disposition.
+
+Minimum rules:
+
+- adapter explicitly marks content unsafe/high severity -> `block_routing`
+- uncertain, unsupported, incomplete, low-confidence, or adapter failure -> `human_review`
+- only explicit sufficiently confident safe assessment -> `allow_routing`
+- media that exists but was not actually assessed -> never `allow_routing`
+- an event with neither assessable text nor assessed media -> `human_review`
+
+Policy output must include machine-readable reason codes.
+
+### Durability
+
+Add a moderation-results persistence boundary associated with one inbound event.
+
+Requirements:
+
+- one active Phase 2 moderation result per event
+- duplicate execution for the same event must return the same persisted result rather than creating duplicates
+- foreign key to `inbound_events`
+- timestamps in UTC
+- no raw provider payloads
+- normalized categories/reasons encoded deterministically
+- persistence remains safe under normal SQLite concurrent duplicate attempts
+
+Do not introduce a provider-specific schema.
+
+### Service
+
+Expose an async service logically equivalent to:
+
+```python
+await moderation_service.moderate(event_id) -> ModerationResult
+```
+
+Behavior:
+
+1. Load durable event.
+2. Return existing moderation result if already completed for that event.
+3. Build normalized moderation request.
+4. Await adapter assessment.
+5. Convert adapter exceptions/malformed evidence into fail-closed human-review result; do not leak raw exception text into persistence.
+6. Apply deterministic policy.
+7. Persist result idempotently.
+8. If a concurrent worker already persisted the result, return the existing result.
+
+This service does not publish, classify, hide/delete content, or call the fatwa bridge.
+
+## Tests
+
+Add automated tests proving at least:
+
+1. Explicit safe text -> `allow_routing`.
+2. Explicit unsafe/high severity -> `block_routing`.
+3. Ambiguous/low-confidence -> `human_review`.
+4. Adapter exception -> durable `human_review` without raw exception/secret persistence.
+5. Media present but unassessed -> not allowed.
+6. Empty/unassessable event -> `human_review`.
+7. All four V1 platforms share the same moderation service/domain semantics.
+8. Duplicate calls produce one moderation row and the same result ID.
+9. Concurrent duplicate moderation attempts produce one row.
+10. Foreign key enforcement remains active.
+11. Existing Phase 0/1 tests remain green.
+12. No live credentials are needed.
+
+## Documentation
+
+Update `docs/ARCHITECTURE.md` to describe the moderation boundary, policy outcomes, fail-closed behavior, and the fact that external enforcement actions are out of scope for this phase.
+
+## Quality gates
+
+Run exactly:
+
+```bash
+ruff check app tests
+mypy app
+pytest
+```
+
+Do not weaken linting, typing, or prior tests.
+
+## Promotion gate
+
+Phase 2 implementation may be prepared and tested while Phase 1 review is pending, but it must not be promoted/merged ahead of Phase 1. Before Phase 2 promotion:
+
+- Phase 1 must be independently accepted and merged or otherwise canonically closed.
+- Phase 2 CI must pass.
+- Phase 2 must receive an independent review separate from the producer.
+
+## Out of scope
+
+- semantic classifier implementation
+- FAQ engine
+- supervisor Telegram transport
+- live platform adapters
+- fatwa bridge
+- publishing dispatcher
+- external hide/delete/report actions
+- production credentials
+
+## Completion
+
+1. Report exact code/test results.
+2. Open a dependent PR referencing Issue #8.
+3. Do not merge it until prerequisite and independent-review gates pass.

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -118,6 +118,24 @@ def test_explicit_safe_text_allows_routing(tmp_path: Path) -> None:
     assert results.count_results() == 1
 
 
+def test_contradictory_safe_assessment_fails_closed(tmp_path: Path) -> None:
+    assessment = ModerationAssessment(
+        verdict=ModerationVerdict.SAFE,
+        severity=ModerationSeverity.HIGH,
+        confidence=0.99,
+        categories=(ModerationCategory.HARMFUL_CONTENT,),
+        text_assessed=True,
+    )
+    adapter = StaticModerationAdapter(assessment)
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="contradictory-safe")
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert result.reasons == (ModerationReason.INVALID_ASSESSMENT,)
+
+
 def test_explicit_high_severity_unsafe_content_blocks_routing(tmp_path: Path) -> None:
     assessment = ModerationAssessment(
         verdict=ModerationVerdict.UNSAFE,

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from app.adapters.contracts import ModerationAdapter
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.moderation import (
+    ModerationAssessment,
+    ModerationCategory,
+    ModerationDisposition,
+    ModerationReason,
+    ModerationRequest,
+    ModerationSeverity,
+    ModerationVerdict,
+)
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.ingestion import IngestionService
+from app.services.moderation import ModerationService
+from app.services.moderation_policy import ModerationPolicy
+
+
+class StaticModerationAdapter:
+    name = "test-moderation"
+    version = "1"
+
+    def __init__(self, assessment: ModerationAssessment) -> None:
+        self.assessment = assessment
+        self.calls = 0
+
+    async def assess(self, request: ModerationRequest) -> ModerationAssessment:
+        self.calls += 1
+        return self.assessment
+
+
+class RaisingModerationAdapter:
+    name = "test-failing-moderation"
+    version = "1"
+
+    async def assess(self, request: ModerationRequest) -> ModerationAssessment:
+        raise RuntimeError("Authorization: Bearer super-secret-value")
+
+
+class MalformedModerationAdapter:
+    name = "test-malformed-moderation"
+    version = "1"
+
+    async def assess(self, request: ModerationRequest) -> object:
+        return {"verdict": "safe"}
+
+
+def _build(
+    tmp_path: Path,
+    adapter: ModerationAdapter,
+) -> tuple[SQLiteDatabase, DurableRepository, ModerationRepository, ModerationService]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    events = DurableRepository(database)
+    results = ModerationRepository(database)
+    service = ModerationService(
+        events=events,
+        results=results,
+        adapter=adapter,
+        policy=ModerationPolicy(minimum_confidence=0.80),
+    )
+    return database, events, results, service
+
+
+def _ingest(
+    events: DurableRepository,
+    *,
+    platform: Platform = Platform.FACEBOOK,
+    key: str = "moderation-event",
+    text: str | None = "مرحبا بكم",
+    media: dict[str, object] | None = None,
+) -> str:
+    service = IngestionService(events)
+    return service.ingest_event(
+        NormalizedInboundEvent(
+            platform=platform,
+            external_event_key=key,
+            text=text,
+            media=media,
+        )
+    ).event.id
+
+
+def _safe_assessment(*, media_assessed: bool = False, confidence: float = 0.99) -> ModerationAssessment:
+    return ModerationAssessment(
+        verdict=ModerationVerdict.SAFE,
+        severity=ModerationSeverity.NONE,
+        confidence=confidence,
+        text_assessed=True,
+        media_assessed=media_assessed,
+    )
+
+
+def test_explicit_safe_text_allows_routing(tmp_path: Path) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment())
+    _, events, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.ALLOW_ROUTING
+    assert result.reasons == (ModerationReason.EXPLICIT_SAFE,)
+    assert results.count_results() == 1
+
+
+def test_explicit_high_severity_unsafe_content_blocks_routing(tmp_path: Path) -> None:
+    assessment = ModerationAssessment(
+        verdict=ModerationVerdict.UNSAFE,
+        severity=ModerationSeverity.HIGH,
+        confidence=0.99,
+        categories=(ModerationCategory.HARMFUL_CONTENT,),
+        text_assessed=True,
+    )
+    adapter = StaticModerationAdapter(assessment)
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.BLOCK_ROUTING
+    assert result.reasons == (ModerationReason.EXPLICIT_UNSAFE,)
+    assert result.categories == (ModerationCategory.HARMFUL_CONTENT,)
+
+
+def test_low_confidence_is_escalated_to_human_review(tmp_path: Path) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment(confidence=0.40))
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert result.reasons == (ModerationReason.LOW_CONFIDENCE,)
+
+
+def test_adapter_failure_is_durable_human_review_without_exception_secret(tmp_path: Path) -> None:
+    database, events, results, service = _build(tmp_path, RaisingModerationAdapter())
+    event_id = _ingest(events)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert result.reasons == (ModerationReason.ADAPTER_FAILURE,)
+    assert result.confidence is None
+    assert results.count_results() == 1
+    with database.connect() as connection:
+        row = connection.execute(
+            "SELECT * FROM moderation_results WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    assert "super-secret-value" not in " ".join(str(value) for value in tuple(row))
+
+
+def test_malformed_adapter_result_fails_closed(tmp_path: Path) -> None:
+    adapter = cast(ModerationAdapter, MalformedModerationAdapter())
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert result.reasons == (ModerationReason.INVALID_ASSESSMENT,)
+    assert result.confidence is None
+
+
+def test_media_present_but_unassessed_cannot_be_allowed(tmp_path: Path) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment(media_assessed=False))
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(
+        events,
+        media={"kind": "image", "media_ref": "normalized-ref-1"},
+    )
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert ModerationReason.MEDIA_UNASSESSED in result.reasons
+
+
+def test_empty_unassessable_event_goes_to_human_review(tmp_path: Path) -> None:
+    assessment = ModerationAssessment(
+        verdict=ModerationVerdict.SAFE,
+        severity=ModerationSeverity.NONE,
+        confidence=0.99,
+    )
+    adapter = StaticModerationAdapter(assessment)
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, text="   ", media=None)
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.HUMAN_REVIEW
+    assert result.reasons == (ModerationReason.NO_ASSESSABLE_CONTENT,)
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_share_the_same_moderation_semantics(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment())
+    _, events, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, platform=platform, key=f"moderation-{platform.value}")
+
+    result = asyncio.run(service.moderate(event_id))
+
+    assert result.disposition is ModerationDisposition.ALLOW_ROUTING
+
+
+def test_duplicate_moderation_calls_return_same_durable_result(tmp_path: Path) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment())
+    _, events, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+
+    first = asyncio.run(service.moderate(event_id))
+    second = asyncio.run(service.moderate(event_id))
+
+    assert first.id == second.id
+    assert adapter.calls == 1
+    assert results.count_results() == 1
+
+
+def test_concurrent_duplicate_moderation_creates_one_result_row(tmp_path: Path) -> None:
+    adapter = StaticModerationAdapter(_safe_assessment())
+    _, events, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="moderation-race")
+
+    def moderate_once(_: int) -> str:
+        return asyncio.run(service.moderate(event_id)).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(moderate_once, range(20)))
+
+    assert len(set(ids)) == 1
+    assert results.count_results() == 1
+
+
+def test_moderation_result_foreign_key_is_enforced(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+
+    with database.connect() as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO moderation_results (
+                id, event_id, disposition, reason_codes_json, categories_json,
+                adapter_name, adapter_version, confidence, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "result-1",
+                "missing-event",
+                "human_review",
+                '["adapter_failure"]',
+                "[]",
+                "test-adapter",
+                "1",
+                None,
+                "2026-09-10T07:00:00+00:00",
+            ),
+        )

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -92,7 +92,11 @@ def _ingest(
     ).event.id
 
 
-def _safe_assessment(*, media_assessed: bool = False, confidence: float = 0.99) -> ModerationAssessment:
+def _safe_assessment(
+    *,
+    media_assessed: bool = False,
+    confidence: float = 0.99,
+) -> ModerationAssessment:
     return ModerationAssessment(
         verdict=ModerationVerdict.SAFE,
         severity=ModerationSeverity.NONE,


### PR DESCRIPTION
## Summary

Implements Issue #8 as a stacked Phase 2 change on top of the current Phase 1 branch.

### Added
- provider-neutral moderation domain models
- async `ModerationAdapter` protocol
- deterministic fail-closed moderation policy
- durable `moderation_results` SQLite table
- idempotent moderation repository/service
- normalized adapter identity and audit metadata
- text/media coverage checks
- adapter-failure and malformed-evidence fail-closed behavior
- contradictory SAFE evidence hardening
- concurrent duplicate moderation protection
- phase-branch CI coverage
- Phase 2 execution prompt and architecture documentation

### Routing-only outcomes
- `allow_routing`
- `human_review`
- `block_routing`

`block_routing` does not hide/delete/report platform content. This phase performs no live external moderation action.

### Safety
- no real credentials
- no live Meta/Instagram/Telegram/YouTube/OpenAI/fatwa calls
- no generated fatwa or user-facing response
- adapter failures do not become ALLOW
- raw adapter exception text is not persisted

### Validation
GitHub Actions run `34449730941` on head `bf4dc2b3960a3b3690d6c76c782d4c23626fe47c`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
This PR intentionally targets `codex/v1-full-build`, not `main`. Phase 1 PR #7 must be independently accepted/canonically closed before this phase can be promoted toward `main`. Phase 2 also requires its own independent review.

Closes #8 only when the stacked prerequisite/promotion gates are satisfied.