### PR TITLE
Phase 3 — Structured Routing Classifier

### DIFF
--- a/app/adapters/contracts.py
+++ b/app/adapters/contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from app.domain.classification import ClassificationAssessment, ClassificationRequest
 from app.domain.moderation import ModerationAssessment, ModerationRequest
 
 
@@ -38,4 +39,22 @@ class ModerationAdapter(Protocol):
 
     async def assess(self, request: ModerationRequest) -> ModerationAssessment:
         """Return normalized moderation evidence without taking external action."""
+        ...
+
+
+class ClassificationAdapter(Protocol):
+    """Structured routing-only semantic classifier boundary."""
+
+    @property
+    def name(self) -> str:
+        """Stable adapter identifier suitable for audit persistence."""
+        ...
+
+    @property
+    def version(self) -> str:
+        """Stable adapter/model version suitable for audit persistence."""
+        ...
+
+    async def classify(self, request: ClassificationRequest) -> ClassificationAssessment:
+        """Return structured routing evidence; never answer the user."""
         ...

--- a/app/domain/classification.py
+++ b/app/domain/classification.py
@@ -1,0 +1,95 @@
+"""Provider-neutral routing-classification domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from app.domain.events import Platform
+
+
+class ClassificationRoute(StrEnum):
+    """Only semantic routing destinations allowed in Gheras V1."""
+
+    FAQ = "FAQ"
+    SUPERVISOR = "SUPERVISOR"
+    FATWA = "FATWA"
+
+
+class ClassificationReason(StrEnum):
+    """Machine-readable reasons for a deterministic local routing decision."""
+
+    CONFIDENT_FAQ = "confident_faq"
+    LOW_CONFIDENCE = "low_confidence"
+    FAQ_KEY_MISSING = "faq_key_missing"
+    RELIGIOUS_SAFETY_OVERRIDE = "religious_safety_override"
+    EXPLICIT_FATWA = "explicit_fatwa"
+    EXPLICIT_SUPERVISOR = "explicit_supervisor"
+    ADAPTER_FAILURE = "adapter_failure"
+    INVALID_ASSESSMENT = "invalid_assessment"
+    NO_CLASSIFIABLE_TEXT = "no_classifiable_text"
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationRequest:
+    """Normalized classifier input derived from an already moderated event."""
+
+    event_id: str
+    platform: Platform
+    text: str | None
+    media: dict[str, Any] | None
+
+    @property
+    def has_text(self) -> bool:
+        return bool(self.text and self.text.strip())
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationAssessment:
+    """Structured routing evidence returned by a classifier adapter."""
+
+    proposed_route: ClassificationRoute
+    confidence: float
+    religious_possible: bool
+    faq_key: str | None = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("classification confidence must be between 0 and 1")
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationDecision:
+    """Deterministic local decision after applying Gheras safety policy."""
+
+    route: ClassificationRoute
+    reasons: tuple[ClassificationReason, ...]
+    faq_key: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.reasons:
+            raise ValueError("classification decision must contain at least one reason")
+        if len(self.reasons) != len(set(self.reasons)):
+            raise ValueError("classification reasons must not contain duplicates")
+        if self.route is ClassificationRoute.FAQ and self.faq_key is None:
+            raise ValueError("FAQ classification decision requires faq_key")
+        if self.route is not ClassificationRoute.FAQ and self.faq_key is not None:
+            raise ValueError("non-FAQ classification decision must not contain faq_key")
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationResult:
+    """Persisted semantic routing result for one durable inbound event."""
+
+    id: str
+    event_id: str
+    route: ClassificationRoute
+    reasons: tuple[ClassificationReason, ...]
+    faq_key: str | None
+    religious_possible: bool | None
+    confidence: float | None
+    adapter_name: str
+    adapter_version: str
+    created_at: datetime

--- a/app/persistence/classification_repository.py
+++ b/app/persistence/classification_repository.py
@@ -1,0 +1,162 @@
+"""SQLite persistence for normalized semantic-routing results."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationResult,
+    ClassificationRoute,
+)
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+_MAX_ADAPTER_ID_LENGTH = 80
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _compact_identifier(value: str, *, field: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if len(normalized) > _MAX_ADAPTER_ID_LENGTH:
+        raise ValueError(f"{field} must be at most {_MAX_ADAPTER_ID_LENGTH} characters")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field} must be a compact identifier")
+    return normalized
+
+
+def _result_from_row(row: sqlite3.Row) -> ClassificationResult:
+    raw_reasons = json.loads(str(row["reason_codes_json"]))
+    if not isinstance(raw_reasons, list):
+        raise RuntimeError("stored classification result has invalid normalized JSON")
+    religious_raw = row["religious_possible"]
+    return ClassificationResult(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        route=ClassificationRoute(str(row["route"])),
+        reasons=tuple(ClassificationReason(str(value)) for value in raw_reasons),
+        faq_key=row["faq_key"],
+        religious_possible=(bool(int(religious_raw)) if religious_raw is not None else None),
+        confidence=(float(row["confidence"]) if row["confidence"] is not None else None),
+        adapter_name=str(row["adapter_name"]),
+        adapter_version=str(row["adapter_version"]),
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+class ClassificationRepository:
+    """Durable idempotency boundary for one classification result per event."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def get_for_event(self, event_id: str) -> ClassificationResult | None:
+        """Load the durable classification result for an event, if present."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM classification_results WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _result_from_row(row) if row is not None else None
+
+    def count_results(self) -> int:
+        """Return the number of stored classification results."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) AS count FROM classification_results"
+            ).fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def create_for_event(
+        self,
+        *,
+        event_id: str,
+        decision: ClassificationDecision,
+        religious_possible: bool | None,
+        confidence: float | None,
+        adapter_name: str,
+        adapter_version: str,
+    ) -> ClassificationResult:
+        """Persist one routing result and return the winner of duplicate races."""
+
+        safe_adapter_name = _compact_identifier(adapter_name, field="adapter_name")
+        safe_adapter_version = _compact_identifier(adapter_version, field="adapter_version")
+        if confidence is not None and not 0.0 <= confidence <= 1.0:
+            raise ValueError("classification confidence must be between 0 and 1")
+
+        result_id = str(uuid4())
+        created_at = _utc_now()
+        reasons_json = json.dumps(
+            sorted(reason.value for reason in decision.reasons),
+            separators=(",", ":"),
+        )
+        religious_db = None if religious_possible is None else int(religious_possible)
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event_exists = connection.execute(
+                "SELECT 1 FROM inbound_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if event_exists is None:
+                connection.rollback()
+                raise EventNotFound(event_id)
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO classification_results (
+                        id, event_id, route, reason_codes_json, faq_key,
+                        religious_possible, confidence, adapter_name,
+                        adapter_version, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        result_id,
+                        event_id,
+                        decision.route.value,
+                        reasons_json,
+                        decision.faq_key,
+                        religious_db,
+                        confidence,
+                        safe_adapter_name,
+                        safe_adapter_version,
+                        _to_timestamp(created_at),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM classification_results WHERE id = ?",
+                    (result_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted classification result could not be reloaded")
+                return _result_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM classification_results WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                return _result_from_row(row)

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -81,4 +81,24 @@ CREATE TABLE IF NOT EXISTS moderation_results (
 
 CREATE INDEX IF NOT EXISTS idx_moderation_results_disposition
 ON moderation_results (disposition, created_at);
+
+CREATE TABLE IF NOT EXISTS classification_results (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    route TEXT NOT NULL CHECK (route IN ('FAQ', 'SUPERVISOR', 'FATWA')),
+    reason_codes_json TEXT NOT NULL,
+    faq_key TEXT,
+    religious_possible INTEGER CHECK (
+        religious_possible IS NULL OR religious_possible IN (0, 1)
+    ),
+    confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    adapter_name TEXT NOT NULL,
+    adapter_version TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
+    CHECK ((route = 'FAQ' AND faq_key IS NOT NULL) OR (route != 'FAQ' AND faq_key IS NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_classification_results_route
+ON classification_results (route, created_at);
 """

--- a/app/services/classification.py
+++ b/app/services/classification.py
@@ -1,0 +1,102 @@
+"""Async semantic routing orchestration after durable moderation."""
+
+from __future__ import annotations
+
+from app.adapters.contracts import ClassificationAdapter
+from app.domain.classification import (
+    ClassificationAssessment,
+    ClassificationRequest,
+    ClassificationResult,
+)
+from app.domain.moderation import ModerationDisposition
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.services.classification_policy import ClassificationPolicy
+
+_UNKNOWN_ADAPTER = "unknown-classifier"
+_UNKNOWN_VERSION = "unknown-version"
+
+
+class ClassificationNotEligible(RuntimeError):
+    """Raised when semantic classification is attempted before moderation allows it."""
+
+
+def _safe_adapter_identity(adapter: ClassificationAdapter) -> tuple[str, str]:
+    try:
+        name = adapter.name
+        version = adapter.version
+    except Exception:
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    if not name.strip() or not version.strip():
+        return _UNKNOWN_ADAPTER, _UNKNOWN_VERSION
+    return name, version
+
+
+class ClassificationService:
+    """Produce one durable routing-only classification for an eligible event."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        moderation: ModerationRepository,
+        results: ClassificationRepository,
+        adapter: ClassificationAdapter,
+        policy: ClassificationPolicy,
+    ) -> None:
+        self.events = events
+        self.moderation = moderation
+        self.results = results
+        self.adapter = adapter
+        self.policy = policy
+
+    async def classify(self, event_id: str) -> ClassificationResult:
+        """Classify only events whose durable moderation result explicitly allows routing."""
+
+        moderation_result = self.moderation.get_for_event(event_id)
+        if (
+            moderation_result is None
+            or moderation_result.disposition is not ModerationDisposition.ALLOW_ROUTING
+        ):
+            raise ClassificationNotEligible(
+                "classification requires durable moderation disposition allow_routing"
+            )
+
+        existing = self.results.get_for_event(event_id)
+        if existing is not None:
+            return existing
+
+        event = self.events.get_event(event_id)
+        request = ClassificationRequest(
+            event_id=event.id,
+            platform=event.platform,
+            text=event.text,
+            media=event.media,
+        )
+        adapter_name, adapter_version = _safe_adapter_identity(self.adapter)
+        religious_possible: bool | None = None
+        confidence: float | None = None
+
+        try:
+            candidate = await self.adapter.classify(request)
+        except Exception:
+            decision = self.policy.adapter_failure()
+        else:
+            if not isinstance(candidate, ClassificationAssessment):
+                decision = self.policy.invalid_assessment()
+            else:
+                religious_possible = candidate.religious_possible
+                confidence = candidate.confidence
+                decision = self.policy.decide(request, candidate)
+
+        return self.results.create_for_event(
+            event_id=event.id,
+            decision=decision,
+            religious_possible=religious_possible,
+            confidence=confidence,
+            adapter_name=adapter_name,
+            adapter_version=adapter_version,
+        )

--- a/app/services/classification_policy.py
+++ b/app/services/classification_policy.py
@@ -1,0 +1,104 @@
+"""Deterministic fail-closed routing policy for classifier evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.domain.classification import (
+    ClassificationAssessment,
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRequest,
+    ClassificationRoute,
+)
+
+_MAX_FAQ_KEY_LENGTH = 128
+
+
+def _valid_faq_key(value: str | None) -> bool:
+    if value is None:
+        return False
+    normalized = value.strip()
+    if not normalized or len(normalized) > _MAX_FAQ_KEY_LENGTH:
+        return False
+    return not any(char.isspace() for char in normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationPolicy:
+    """Apply Gheras religious-safety and low-confidence routing rules."""
+
+    minimum_faq_confidence: float
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.minimum_faq_confidence <= 1.0:
+            raise ValueError("minimum_faq_confidence must be between 0 and 1")
+
+    def decide(
+        self,
+        request: ClassificationRequest,
+        assessment: ClassificationAssessment,
+    ) -> ClassificationDecision:
+        """Return the local authoritative route from normalized evidence."""
+
+        if not request.has_text:
+            return ClassificationDecision(
+                route=ClassificationRoute.SUPERVISOR,
+                reasons=(ClassificationReason.NO_CLASSIFIABLE_TEXT,),
+            )
+
+        if assessment.religious_possible:
+            return ClassificationDecision(
+                route=ClassificationRoute.FATWA,
+                reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+            )
+
+        if assessment.proposed_route is ClassificationRoute.FATWA:
+            return ClassificationDecision(
+                route=ClassificationRoute.FATWA,
+                reasons=(ClassificationReason.EXPLICIT_FATWA,),
+            )
+
+        if assessment.proposed_route is ClassificationRoute.SUPERVISOR:
+            return ClassificationDecision(
+                route=ClassificationRoute.SUPERVISOR,
+                reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+            )
+
+        if assessment.proposed_route is ClassificationRoute.FAQ:
+            if assessment.confidence < self.minimum_faq_confidence:
+                return ClassificationDecision(
+                    route=ClassificationRoute.SUPERVISOR,
+                    reasons=(ClassificationReason.LOW_CONFIDENCE,),
+                )
+            if not _valid_faq_key(assessment.faq_key):
+                return ClassificationDecision(
+                    route=ClassificationRoute.SUPERVISOR,
+                    reasons=(ClassificationReason.FAQ_KEY_MISSING,),
+                )
+            assert assessment.faq_key is not None
+            return ClassificationDecision(
+                route=ClassificationRoute.FAQ,
+                reasons=(ClassificationReason.CONFIDENT_FAQ,),
+                faq_key=assessment.faq_key.strip(),
+            )
+
+        return self.invalid_assessment()
+
+    @staticmethod
+    def adapter_failure() -> ClassificationDecision:
+        """Fail closed to human supervision when the classifier is unavailable."""
+
+        return ClassificationDecision(
+            route=ClassificationRoute.SUPERVISOR,
+            reasons=(ClassificationReason.ADAPTER_FAILURE,),
+        )
+
+    @staticmethod
+    def invalid_assessment() -> ClassificationDecision:
+        """Fail closed when structured classifier evidence violates the contract."""
+
+        return ClassificationDecision(
+            route=ClassificationRoute.SUPERVISOR,
+            reasons=(ClassificationReason.INVALID_ASSESSMENT,),
+        )

--- a/app/services/classification_policy.py
+++ b/app/services/classification_policy.py
@@ -41,16 +41,16 @@ class ClassificationPolicy:
     ) -> ClassificationDecision:
         """Return the local authoritative route from normalized evidence."""
 
-        if not request.has_text:
-            return ClassificationDecision(
-                route=ClassificationRoute.SUPERVISOR,
-                reasons=(ClassificationReason.NO_CLASSIFIABLE_TEXT,),
-            )
-
         if assessment.religious_possible:
             return ClassificationDecision(
                 route=ClassificationRoute.FATWA,
                 reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+            )
+
+        if not request.has_text:
+            return ClassificationDecision(
+                route=ClassificationRoute.SUPERVISOR,
+                reasons=(ClassificationReason.NO_CLASSIFIABLE_TEXT,),
             )
 
         if assessment.proposed_route is ClassificationRoute.FATWA:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,7 @@ The V1 durable core uses SQLite behind repository/service abstractions and conta
 - `processing_attempts`: sanitized attempt history and retry metadata.
 - `outbound_actions`: durable publish intents/results with unique idempotency keys.
 - `moderation_results`: one normalized, auditable moderation routing decision per inbound event.
+- `classification_results`: one normalized, auditable semantic route per eligible inbound event.
 
 The uniqueness boundary for inbound work is `(platform, external_event_key)`. The uniqueness boundary for outbound work is `idempotency_key`.
 
@@ -85,6 +86,39 @@ Moderation adapter exceptions are converted to a normalized human-review result.
 
 The moderation result is idempotent per `event_id`. Duplicate or racing workers resolve to the same persisted result instead of creating multiple moderation rows.
 
+### Classification boundary
+
+Semantic classification is eligible only after a durable moderation result explicitly says `allow_routing`. Missing moderation, `human_review`, or `block_routing` prevents the classifier from running.
+
+Classification is split into three responsibilities:
+
+1. A provider-neutral async `ClassificationAdapter` returns structured routing evidence only.
+2. A deterministic local `ClassificationPolicy` applies Gheras safety rules and selects the authoritative route.
+3. A durable classification repository stores one normalized result per inbound event.
+
+The only V1 semantic routes are:
+
+- `FAQ`
+- `SUPERVISOR`
+- `FATWA`
+
+The adapter does not produce user-facing answer text. Its normalized evidence is limited to routing fields such as proposed route, confidence, whether religious content may be involved, and an optional FAQ key.
+
+The local policy is authoritative. Important fail-closed rules include:
+
+- `religious_possible=true` always forces `FATWA`, even if the adapter proposed FAQ or the event has no classifiable text.
+- an explicit FATWA proposal remains `FATWA`.
+- low-confidence FAQ candidates become `SUPERVISOR`.
+- FAQ candidates without a valid compact `faq_key` become `SUPERVISOR`.
+- adapter failures and malformed structured evidence become `SUPERVISOR`, never FAQ.
+- content without classifiable text and without a religious signal becomes `SUPERVISOR`.
+
+A `FATWA` route is only a routing decision. It does not contain, create, infer, or publish a religious ruling. The later fatwa bridge remains the only boundary to the existing supervised fatwa system.
+
+`classification_results` stores normalized route evidence and audit metadata only. It deliberately has no answer, prompt, chain-of-thought, raw provider response, or provider payload column.
+
+The classification result is idempotent per `event_id`. Sequential or racing workers converge on the same persisted result.
+
 ### AI adapters
 
 Moderation and classification are separate adapters. Classification is routing-only; religious questions must never receive an AI-generated religious answer.
@@ -110,12 +144,14 @@ Publishing is separated from classification and response composition. A dispatch
 - Persist first, process later.
 - Inbound platform events are idempotent.
 - Moderation decisions are durable and idempotent per inbound event.
+- Classification decisions are durable and idempotent per eligible inbound event.
 - Outbound replies/actions are idempotent.
 - Accepted work and processing state survive process restarts.
 - SQLite foreign keys are enabled.
 - WAL mode and a sensible busy timeout are preferred where safe for V1.
 - External API failures must not silently lose accepted work.
 - Low-confidence routing escalates to a human rather than guessing.
+- Possible religious content fails toward the FATWA route rather than an automatic answer.
 - Secrets are supplied through process environment variables and are never committed.
 - Raw external payloads are not blindly persisted; store normalized fields required by the router.
 
@@ -126,3 +162,5 @@ Phase 0 established configuration, the HTTP application, adapter interfaces, tes
 Phase 1 implements the durable core and intentionally contains no real Meta, Telegram, YouTube/Google, OpenAI, or fatwa-bot calls.
 
 Phase 2 adds the mock-first moderation domain, async adapter contract, deterministic fail-closed policy, durable moderation-result repository, and idempotent moderation service. It still performs no live external moderation call and no external hide/delete/report action.
+
+Phase 3 adds the mock-first structured classification domain, async adapter contract, moderation eligibility gate, deterministic religious-safety routing policy, durable classification-result repository, and idempotent classification service. It performs no live model call and creates no user-facing answer or fatwa.

--- a/prompts/03_PHASE3_CLASSIFICATION.md
+++ b/prompts/03_PHASE3_CLASSIFICATION.md
@@ -1,0 +1,165 @@
+# Execution Prompt — Phase 3: Structured Routing Classifier
+
+Implement GitHub Issue #10 on branch `phase/03-classification`, stacked on the Phase 2 moderation head.
+
+## Model-aware execution profile
+
+- Executor class: coding agent / repository producer.
+- Preferred executor when available: Codex-class coding agent.
+- Prompt shape: explicit typed contracts, deterministic local safety policy, provider isolation, exhaustive fail-closed tests.
+- No model-specific optimization claim is made beyond governed prompt structure; product truth and safety invariants are fixed regardless of executor model.
+
+## Read first
+
+- `AGENTS.md`
+- `docs/PROJECT_SPEC_AR.md`
+- `docs/ARCHITECTURE.md`
+- `prompts/02_PHASE2_MODERATION.md`
+- GitHub Issue #10
+
+## Objective
+
+Build a provider-neutral, mock-first semantic routing classifier that runs only after a durable `allow_routing` moderation result and produces exactly one of three routes:
+
+- `FAQ`
+- `SUPERVISOR`
+- `FATWA`
+
+The classifier selects a route and optional FAQ key only. It never creates user-facing answer text.
+
+## Hard safety constraints
+
+1. AI must never generate or deliver a religious ruling/fatwa.
+2. If content may be religious, local policy must prefer `FATWA` over FAQ/SUPERVISOR whenever uncertainty exists.
+3. Low-confidence non-religious FAQ candidates become `SUPERVISOR`.
+4. FAQ is valid only with a compact intent/key for a later approved-answer store.
+5. Model/provider free text must never control execution directly.
+6. Malformed adapter results or adapter failures become a durable non-automatic route; never FAQ.
+7. Classification is forbidden unless durable moderation disposition is `allow_routing`.
+8. No real OpenAI, Meta, Telegram, YouTube/Google, or fatwa-bot calls in this phase.
+9. Persist normalized routing evidence only, never raw model responses, credentials, auth headers, chain-of-thought, or full provider payloads.
+10. One durable classification result per inbound event; duplicate/racing executions are idempotent.
+
+## Domain contract
+
+Add typed provider-neutral models for:
+
+- classification route enum
+- normalized adapter assessment
+- deterministic policy decision/reason codes
+- persisted classification result
+
+The adapter assessment should contain only fields necessary for routing, such as:
+
+- proposed route
+- confidence in [0,1]
+- `religious_possible` boolean
+- optional `faq_key`
+
+Do not store answer text.
+
+## Adapter boundary
+
+Expose a mockable async protocol logically equivalent to:
+
+```python
+class ClassificationAdapter(Protocol):
+    async def classify(self, request: ClassificationRequest) -> ClassificationAssessment: ...
+```
+
+Adapter identity/version must be auditable. The request is built from the normalized durable event, not raw platform payloads.
+
+## Deterministic policy
+
+Minimum rules:
+
+- `religious_possible=True` => route `FATWA` regardless of an adapter proposal for FAQ/SUPERVISOR.
+- explicit FATWA proposal => `FATWA`.
+- explicit SUPERVISOR proposal => `SUPERVISOR`.
+- FAQ proposal below configured minimum confidence => `SUPERVISOR`.
+- FAQ proposal without a valid compact `faq_key` => `SUPERVISOR`.
+- sufficiently confident FAQ proposal with valid key and no religious signal => `FAQ`.
+- adapter failure/malformed assessment => `SUPERVISOR`.
+
+The local policy is authoritative; the provider proposal is evidence only.
+
+## Durability
+
+Add a `classification_results` table with one row per event and normalized fields only. Include:
+
+- id
+- event_id unique FK
+- route
+- reason code(s)
+- faq_key nullable
+- religious_possible
+- confidence nullable
+- adapter_name/version
+- created_at UTC
+
+No raw model response column.
+
+## Service
+
+Expose an async service logically equivalent to:
+
+```python
+await classification_service.classify(event_id) -> ClassificationResult
+```
+
+Behavior:
+
+1. Return existing durable result if present.
+2. Verify the event has a durable moderation result.
+3. Refuse classification unless moderation is `allow_routing`.
+4. Load the normalized inbound event.
+5. Call the async adapter.
+6. Convert adapter failure/malformed evidence to a normalized fail-closed decision.
+7. Apply local policy.
+8. Persist idempotently and return the winner of duplicate races.
+
+No publishing, FAQ lookup, supervisor transport, or fatwa-bot call in this phase.
+
+## Tests
+
+Prove at least:
+
+1. confident FAQ + valid key => FAQ.
+2. low-confidence FAQ => SUPERVISOR.
+3. FAQ without key => SUPERVISOR.
+4. `religious_possible=True` overrides FAQ to FATWA.
+5. explicit FATWA => FATWA.
+6. explicit SUPERVISOR => SUPERVISOR.
+7. adapter failure => durable SUPERVISOR without raw exception secret persistence.
+8. malformed adapter result => SUPERVISOR.
+9. classification cannot run when moderation is absent/human-review/block-routing.
+10. all four V1 platforms use the same classification semantics.
+11. duplicate sequential calls return one result and avoid repeat adapter execution.
+12. concurrent duplicate calls produce one row.
+13. SQLite FK enforcement remains active.
+14. no answer text or raw provider payload is stored.
+15. all existing Phase 0/1/2 tests remain green.
+
+## Quality gates
+
+Run:
+
+```bash
+ruff check app tests
+mypy app
+pytest
+```
+
+## Promotion gate
+
+This is a stacked phase. Do not promote it ahead of Phase 1/2 canonical closure. It also requires its own independent review and CI PASS before promotion.
+
+## Out of scope
+
+- approved FAQ answer retrieval
+- supervisor transport
+- live OpenAI call
+- platform adapters
+- fatwa-bot bridge
+- publishing
+- production credentials

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from app.adapters.contracts import ClassificationAdapter
+from app.domain.classification import (
+    ClassificationAssessment,
+    ClassificationReason,
+    ClassificationRequest,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.moderation import (
+    ModerationDecision,
+    ModerationDisposition,
+    ModerationReason,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.classification import ClassificationNotEligible, ClassificationService
+from app.services.classification_policy import ClassificationPolicy
+from app.services.ingestion import IngestionService
+
+
+class StaticClassificationAdapter:
+    name = "test-classifier"
+    version = "1"
+
+    def __init__(self, assessment: ClassificationAssessment) -> None:
+        self.assessment = assessment
+        self.calls = 0
+
+    async def classify(self, request: ClassificationRequest) -> ClassificationAssessment:
+        self.calls += 1
+        return self.assessment
+
+
+class RaisingClassificationAdapter:
+    name = "test-failing-classifier"
+    version = "1"
+
+    async def classify(self, request: ClassificationRequest) -> ClassificationAssessment:
+        raise RuntimeError("Authorization: Bearer classifier-secret-value")
+
+
+class MalformedClassificationAdapter:
+    name = "test-malformed-classifier"
+    version = "1"
+
+    async def classify(self, request: ClassificationRequest) -> object:
+        return {"route": "FAQ", "answer": "should never be accepted"}
+
+
+def _build(
+    tmp_path: Path,
+    adapter: ClassificationAdapter,
+) -> tuple[
+    SQLiteDatabase,
+    DurableRepository,
+    ModerationRepository,
+    ClassificationRepository,
+    ClassificationService,
+]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    events = DurableRepository(database)
+    moderation = ModerationRepository(database)
+    results = ClassificationRepository(database)
+    service = ClassificationService(
+        events=events,
+        moderation=moderation,
+        results=results,
+        adapter=adapter,
+        policy=ClassificationPolicy(minimum_faq_confidence=0.80),
+    )
+    return database, events, moderation, results, service
+
+
+def _ingest(
+    events: DurableRepository,
+    *,
+    platform: Platform = Platform.FACEBOOK,
+    key: str = "classification-event",
+    text: str | None = "متى يبدأ التسجيل؟",
+) -> str:
+    return IngestionService(events).ingest_event(
+        NormalizedInboundEvent(
+            platform=platform,
+            external_event_key=key,
+            text=text,
+        )
+    ).event.id
+
+
+def _persist_moderation(
+    moderation: ModerationRepository,
+    event_id: str,
+    disposition: ModerationDisposition,
+) -> None:
+    reason = (
+        ModerationReason.EXPLICIT_SAFE
+        if disposition is ModerationDisposition.ALLOW_ROUTING
+        else ModerationReason.EXPLICIT_UNSAFE
+    )
+    moderation.create_for_event(
+        event_id=event_id,
+        decision=ModerationDecision(disposition=disposition, reasons=(reason,)),
+        categories=(),
+        adapter_name="test-moderation",
+        adapter_version="1",
+        confidence=0.99,
+    )
+
+
+def _faq_assessment(
+    *,
+    confidence: float = 0.99,
+    religious_possible: bool = False,
+    faq_key: str | None = "registration.status",
+) -> ClassificationAssessment:
+    return ClassificationAssessment(
+        proposed_route=ClassificationRoute.FAQ,
+        confidence=confidence,
+        religious_possible=religious_possible,
+        faq_key=faq_key,
+    )
+
+
+def test_confident_faq_with_valid_key_routes_to_faq(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.FAQ
+    assert result.faq_key == "registration.status"
+    assert result.reasons == (ClassificationReason.CONFIDENT_FAQ,)
+    assert results.count_results() == 1
+
+
+def test_low_confidence_faq_routes_to_supervisor(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment(confidence=0.40))
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.faq_key is None
+    assert result.reasons == (ClassificationReason.LOW_CONFIDENCE,)
+
+
+def test_faq_without_key_routes_to_supervisor(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment(faq_key=None))
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events)
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.reasons == (ClassificationReason.FAQ_KEY_MISSING,)
+
+
+def test_religious_possible_overrides_faq_to_fatwa(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment(religious_possible=True))
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="religious-override", text="ما حكم هذا الأمر؟")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.FATWA
+    assert result.faq_key is None
+    assert result.religious_possible is True
+    assert result.reasons == (ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,)
+
+
+def test_explicit_fatwa_route_is_preserved(tmp_path: Path) -> None:
+    assessment = ClassificationAssessment(
+        proposed_route=ClassificationRoute.FATWA,
+        confidence=0.55,
+        religious_possible=False,
+    )
+    adapter = StaticClassificationAdapter(assessment)
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="explicit-fatwa", text="سؤال يحتاج فتوى")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.FATWA
+    assert result.reasons == (ClassificationReason.EXPLICIT_FATWA,)
+
+
+def test_explicit_supervisor_route_is_preserved(tmp_path: Path) -> None:
+    assessment = ClassificationAssessment(
+        proposed_route=ClassificationRoute.SUPERVISOR,
+        confidence=0.99,
+        religious_possible=False,
+    )
+    adapter = StaticClassificationAdapter(assessment)
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="explicit-supervisor")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.reasons == (ClassificationReason.EXPLICIT_SUPERVISOR,)
+
+
+def test_adapter_failure_routes_to_supervisor_without_secret_persistence(
+    tmp_path: Path,
+) -> None:
+    database, events, moderation, results, service = _build(
+        tmp_path,
+        RaisingClassificationAdapter(),
+    )
+    event_id = _ingest(events, key="classifier-failure")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.reasons == (ClassificationReason.ADAPTER_FAILURE,)
+    assert result.confidence is None
+    assert results.count_results() == 1
+    with database.connect() as connection:
+        row = connection.execute(
+            "SELECT * FROM classification_results WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    assert "classifier-secret-value" not in " ".join(str(value) for value in tuple(row))
+
+
+def test_malformed_adapter_result_routes_to_supervisor(tmp_path: Path) -> None:
+    adapter = cast(ClassificationAdapter, MalformedClassificationAdapter())
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="malformed-classifier")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.reasons == (ClassificationReason.INVALID_ASSESSMENT,)
+    assert result.confidence is None
+
+
+@pytest.mark.parametrize(
+    "disposition",
+    [
+        None,
+        ModerationDisposition.HUMAN_REVIEW,
+        ModerationDisposition.BLOCK_ROUTING,
+    ],
+)
+def test_classification_requires_allow_routing_moderation(
+    tmp_path: Path,
+    disposition: ModerationDisposition | None,
+) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key=f"moderation-gate-{disposition}")
+    if disposition is not None:
+        _persist_moderation(moderation, event_id, disposition)
+
+    with pytest.raises(ClassificationNotEligible, match="allow_routing"):
+        asyncio.run(service.classify(event_id))
+
+    assert adapter.calls == 0
+    assert results.count_results() == 0
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_share_classification_semantics(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(
+        events,
+        platform=platform,
+        key=f"classification-{platform.value}",
+    )
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.FAQ
+
+
+def test_duplicate_classification_calls_reuse_result_and_adapter_call(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="classification-duplicate")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    first = asyncio.run(service.classify(event_id))
+    second = asyncio.run(service.classify(event_id))
+
+    assert first.id == second.id
+    assert adapter.calls == 1
+    assert results.count_results() == 1
+
+
+def test_concurrent_duplicate_classification_creates_one_result_row(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, results, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="classification-race")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    def classify_once(_: int) -> str:
+        return asyncio.run(service.classify(event_id)).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(classify_once, range(20)))
+
+    assert len(set(ids)) == 1
+    assert results.count_results() == 1
+
+
+def test_no_classifiable_text_routes_to_supervisor(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment())
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="empty-text", text="   ")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.SUPERVISOR
+    assert result.reasons == (ClassificationReason.NO_CLASSIFIABLE_TEXT,)
+
+
+def test_classification_result_foreign_key_is_enforced(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+
+    with database.connect() as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO classification_results (
+                id, event_id, route, reason_codes_json, faq_key,
+                religious_possible, confidence, adapter_name,
+                adapter_version, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "classification-1",
+                "missing-event",
+                "SUPERVISOR",
+                '["adapter_failure"]',
+                None,
+                None,
+                None,
+                "test-classifier",
+                "1",
+                "2026-09-10T07:00:00+00:00",
+            ),
+        )
+
+
+def test_classification_schema_has_no_answer_or_raw_provider_columns(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+
+    with database.connect() as connection:
+        rows = connection.execute("PRAGMA table_info(classification_results)").fetchall()
+
+    column_names = {str(row["name"]) for row in rows}
+    forbidden_fragments = {"answer", "response", "payload", "prompt", "chain"}
+    assert all(
+        not any(fragment in name.lower() for fragment in forbidden_fragments)
+        for name in column_names
+    )

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -187,6 +187,18 @@ def test_religious_possible_overrides_faq_to_fatwa(tmp_path: Path) -> None:
     assert result.reasons == (ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,)
 
 
+def test_religious_possible_overrides_missing_text_to_fatwa(tmp_path: Path) -> None:
+    adapter = StaticClassificationAdapter(_faq_assessment(religious_possible=True))
+    _, events, moderation, _, service = _build(tmp_path, adapter)
+    event_id = _ingest(events, key="religious-no-text", text="   ")
+    _persist_moderation(moderation, event_id, ModerationDisposition.ALLOW_ROUTING)
+
+    result = asyncio.run(service.classify(event_id))
+
+    assert result.route is ClassificationRoute.FATWA
+    assert result.reasons == (ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,)
+
+
 def test_explicit_fatwa_route_is_preserved(tmp_path: Path) -> None:
     assessment = ClassificationAssessment(
         proposed_route=ClassificationRoute.FATWA,


### PR DESCRIPTION
## Summary

Implements Issue #10 as a stacked Phase 3 change above the Moderation branch.

### Added
- provider-neutral classification domain contract
- async `ClassificationAdapter`
- moderation eligibility gate: classification only after durable `allow_routing`
- deterministic local routing policy for FAQ / SUPERVISOR / FATWA
- religious-safety override: `religious_possible=true` always routes FATWA, including no-text cases
- low-confidence FAQ -> SUPERVISOR
- FAQ requires compact `faq_key`
- malformed/provider failure -> SUPERVISOR
- durable idempotent `classification_results`
- concurrent duplicate protection
- no answer/raw response/prompt/chain-of-thought persistence
- architecture and execution-prompt documentation

### Safety boundary
Classification produces routing evidence only. It never generates, infers, or publishes a fatwa or any user-facing answer.

### Validation
GitHub Actions run `34450488946` on head `470c2dd14f3af0429220cb57cb8eb897c5441b34`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
This PR targets `phase/02-moderation`, not `main`. Phase 1 and Phase 2 must be independently reviewed/canonically closed first. Phase 3 also requires its own independent review before promotion.

Issue #10 is considered implementation-complete only at the stacked branch level until those promotion gates pass.