### PR TITLE
Phase 4 — Approved FAQ Store & Resolution Engine

### DIFF
--- a/app/domain/faq.py
+++ b/app/domain/faq.py
@@ -60,7 +60,7 @@ class FAQResolution:
 
 @dataclass(frozen=True, slots=True)
 class FAQResolutionResult:
-    """Resolution plus answer text only when an approved active entry resolved."""
+    """Resolution plus answer text only while the exact approved entry stays active."""
 
     resolution: FAQResolution
     entry: FAQEntry | None
@@ -71,4 +71,6 @@ class FAQResolutionResult:
             return None
         if self.entry is None:
             raise RuntimeError("resolved FAQ result is missing its approved entry")
+        if self.entry.status is not FAQEntryStatus.ACTIVE:
+            return None
         return self.entry.answer_text

--- a/app/domain/faq.py
+++ b/app/domain/faq.py
@@ -1,0 +1,74 @@
+"""Approved FAQ domain models for traceable, non-generated operational answers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class FAQEntryStatus(StrEnum):
+    """Lifecycle state for one immutable FAQ version row."""
+
+    ACTIVE = "active"
+    DISABLED = "disabled"
+
+
+class FAQResolutionStatus(StrEnum):
+    """Outcome of resolving an eligible FAQ classification."""
+
+    RESOLVED = "resolved"
+    SUPERVISOR_REQUIRED = "supervisor_required"
+
+
+class FAQResolutionReason(StrEnum):
+    """Machine-readable reason for a FAQ resolution outcome."""
+
+    APPROVED_ENTRY = "approved_entry"
+    ENTRY_NOT_FOUND = "entry_not_found"
+    ENTRY_DISABLED = "entry_disabled"
+    INVALID_FAQ_KEY = "invalid_faq_key"
+
+
+@dataclass(frozen=True, slots=True)
+class FAQEntry:
+    """One immutable approved-answer version."""
+
+    id: str
+    faq_key: str
+    version: int
+    answer_text: str
+    source_ref: str
+    status: FAQEntryStatus
+    approved_by: str
+    approved_at: datetime
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FAQResolution:
+    """Durable resolution linked to exact classification and FAQ evidence."""
+
+    id: str
+    event_id: str
+    classification_result_id: str
+    faq_entry_id: str | None
+    status: FAQResolutionStatus
+    reason: FAQResolutionReason
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FAQResolutionResult:
+    """Resolution plus answer text only when an approved active entry resolved."""
+
+    resolution: FAQResolution
+    entry: FAQEntry | None
+
+    @property
+    def answer_text(self) -> str | None:
+        if self.resolution.status is not FAQResolutionStatus.RESOLVED:
+            return None
+        if self.entry is None:
+            raise RuntimeError("resolved FAQ result is missing its approved entry")
+        return self.entry.answer_text

--- a/app/persistence/faq_repository.py
+++ b/app/persistence/faq_repository.py
@@ -1,0 +1,334 @@
+"""SQLite repository for approved FAQ versions and durable resolutions."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.faq import (
+    FAQEntry,
+    FAQEntryStatus,
+    FAQResolution,
+    FAQResolutionReason,
+    FAQResolutionStatus,
+)
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+_MAX_FAQ_KEY_LENGTH = 128
+_MAX_APPROVER_LENGTH = 128
+_MAX_SOURCE_REF_LENGTH = 512
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _compact_key(value: str) -> str:
+    normalized = value.strip()
+    if not normalized or len(normalized) > _MAX_FAQ_KEY_LENGTH:
+        raise ValueError("faq_key must be a compact identifier of at most 128 characters")
+    if any(char.isspace() for char in normalized):
+        raise ValueError("faq_key must not contain whitespace")
+    return normalized
+
+
+def _bounded_text(value: str, *, field: str, maximum: int | None = None) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if maximum is not None and len(normalized) > maximum:
+        raise ValueError(f"{field} must be at most {maximum} characters")
+    return normalized
+
+
+def _entry_from_row(row: sqlite3.Row) -> FAQEntry:
+    return FAQEntry(
+        id=str(row["id"]),
+        faq_key=str(row["faq_key"]),
+        version=int(row["version"]),
+        answer_text=str(row["answer_text"]),
+        source_ref=str(row["source_ref"]),
+        status=FAQEntryStatus(str(row["status"])),
+        approved_by=str(row["approved_by"]),
+        approved_at=_from_timestamp(str(row["approved_at"])),
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+def _resolution_from_row(row: sqlite3.Row) -> FAQResolution:
+    entry_id = row["faq_entry_id"]
+    return FAQResolution(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        classification_result_id=str(row["classification_result_id"]),
+        faq_entry_id=str(entry_id) if entry_id is not None else None,
+        status=FAQResolutionStatus(str(row["status"])),
+        reason=FAQResolutionReason(str(row["reason_code"])),
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+class FAQRepository:
+    """Store immutable FAQ content versions and one durable resolution per event."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def create_version(
+        self,
+        *,
+        faq_key: str,
+        answer_text: str,
+        source_ref: str,
+        approved_by: str,
+        approved_at: datetime,
+        activate: bool = True,
+    ) -> FAQEntry:
+        """Append a FAQ version; never rewrite historical answer/provenance content."""
+
+        key = _compact_key(faq_key)
+        answer = _bounded_text(answer_text, field="answer_text")
+        source = _bounded_text(source_ref, field="source_ref", maximum=_MAX_SOURCE_REF_LENGTH)
+        approver = _bounded_text(
+            approved_by,
+            field="approved_by",
+            maximum=_MAX_APPROVER_LENGTH,
+        )
+        approved_timestamp = _to_timestamp(approved_at)
+        now = _utc_now()
+        entry_id = str(uuid4())
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT COALESCE(MAX(version), 0) + 1 AS next_version "
+                "FROM faq_entries WHERE faq_key = ?",
+                (key,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise RuntimeError("could not allocate FAQ version")
+            version = int(row["next_version"])
+
+            if activate:
+                connection.execute(
+                    "UPDATE faq_entries SET status = 'disabled' "
+                    "WHERE faq_key = ? AND status = 'active'",
+                    (key,),
+                )
+
+            connection.execute(
+                """
+                INSERT INTO faq_entries (
+                    id, faq_key, version, answer_text, source_ref, status,
+                    approved_by, approved_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry_id,
+                    key,
+                    version,
+                    answer,
+                    source,
+                    FAQEntryStatus.ACTIVE.value if activate else FAQEntryStatus.DISABLED.value,
+                    approver,
+                    approved_timestamp,
+                    _to_timestamp(now),
+                ),
+            )
+            created = connection.execute(
+                "SELECT * FROM faq_entries WHERE id = ?",
+                (entry_id,),
+            ).fetchone()
+            connection.commit()
+
+        if created is None:
+            raise RuntimeError("inserted FAQ entry could not be reloaded")
+        return _entry_from_row(created)
+
+    def disable_active(self, faq_key: str) -> FAQEntry | None:
+        """Disable the currently active version without deleting historical evidence."""
+
+        key = _compact_key(faq_key)
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM faq_entries WHERE faq_key = ? AND status = 'active'",
+                (key,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return None
+            connection.execute(
+                "UPDATE faq_entries SET status = 'disabled' WHERE id = ?",
+                (str(row["id"]),),
+            )
+            updated = connection.execute(
+                "SELECT * FROM faq_entries WHERE id = ?",
+                (str(row["id"]),),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("disabled FAQ entry could not be reloaded")
+        return _entry_from_row(updated)
+
+    def get_active(self, faq_key: str) -> FAQEntry | None:
+        """Return the exact active FAQ entry; no fuzzy or substitute lookup."""
+
+        key = _compact_key(faq_key)
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM faq_entries WHERE faq_key = ? AND status = 'active'",
+                (key,),
+            ).fetchone()
+        return _entry_from_row(row) if row is not None else None
+
+    def get_entry(self, entry_id: str) -> FAQEntry:
+        """Load one immutable FAQ version by internal identifier."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM faq_entries WHERE id = ?",
+                (entry_id,),
+            ).fetchone()
+        if row is None:
+            raise LookupError(entry_id)
+        return _entry_from_row(row)
+
+    def has_versions(self, faq_key: str) -> bool:
+        """Return whether any exact historical version exists for this key."""
+
+        key = _compact_key(faq_key)
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT 1 FROM faq_entries WHERE faq_key = ? LIMIT 1",
+                (key,),
+            ).fetchone()
+        return row is not None
+
+    def list_versions(self, faq_key: str) -> tuple[FAQEntry, ...]:
+        """Return exact-key versions in ascending version order."""
+
+        key = _compact_key(faq_key)
+        with self.database.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM faq_entries WHERE faq_key = ? ORDER BY version ASC",
+                (key,),
+            ).fetchall()
+        return tuple(_entry_from_row(row) for row in rows)
+
+    def count_entries(self) -> int:
+        """Return FAQ-entry count; a fresh database must have zero production seeds."""
+
+        with self.database.connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM faq_entries").fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def get_resolution(self, event_id: str) -> FAQResolution | None:
+        """Return the durable FAQ resolution for an event, if present."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM faq_resolutions WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _resolution_from_row(row) if row is not None else None
+
+    def count_resolutions(self) -> int:
+        """Return FAQ-resolution count."""
+
+        with self.database.connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM faq_resolutions").fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def create_resolution(
+        self,
+        *,
+        event_id: str,
+        classification_result_id: str,
+        status: FAQResolutionStatus,
+        reason: FAQResolutionReason,
+        faq_entry_id: str | None,
+    ) -> FAQResolution:
+        """Persist one resolution per event and return the winner of duplicate races."""
+
+        if status is FAQResolutionStatus.RESOLVED:
+            if reason is not FAQResolutionReason.APPROVED_ENTRY or faq_entry_id is None:
+                raise ValueError("resolved FAQ requires exact approved entry evidence")
+        elif reason is FAQResolutionReason.APPROVED_ENTRY or faq_entry_id is not None:
+            raise ValueError("supervisor-required FAQ resolution cannot carry an approved entry")
+
+        resolution_id = str(uuid4())
+        now = _utc_now()
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event_exists = connection.execute(
+                "SELECT 1 FROM inbound_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if event_exists is None:
+                connection.rollback()
+                raise EventNotFound(event_id)
+            classification = connection.execute(
+                "SELECT event_id FROM classification_results WHERE id = ?",
+                (classification_result_id,),
+            ).fetchone()
+            if classification is None or str(classification["event_id"]) != event_id:
+                connection.rollback()
+                raise ValueError("classification result does not belong to event")
+            if faq_entry_id is not None:
+                entry = connection.execute(
+                    "SELECT status FROM faq_entries WHERE id = ?",
+                    (faq_entry_id,),
+                ).fetchone()
+                if entry is None or str(entry["status"]) != FAQEntryStatus.ACTIVE.value:
+                    connection.rollback()
+                    raise ValueError("resolved FAQ entry must still be active")
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO faq_resolutions (
+                        id, event_id, classification_result_id, faq_entry_id,
+                        status, reason_code, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        resolution_id,
+                        event_id,
+                        classification_result_id,
+                        faq_entry_id,
+                        status.value,
+                        reason.value,
+                        _to_timestamp(now),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM faq_resolutions WHERE id = ?",
+                    (resolution_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted FAQ resolution could not be reloaded")
+                return _resolution_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM faq_resolutions WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                return _resolution_from_row(row)

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -101,4 +101,51 @@ CREATE TABLE IF NOT EXISTS classification_results (
 
 CREATE INDEX IF NOT EXISTS idx_classification_results_route
 ON classification_results (route, created_at);
+
+CREATE TABLE IF NOT EXISTS faq_entries (
+    id TEXT PRIMARY KEY,
+    faq_key TEXT NOT NULL,
+    version INTEGER NOT NULL CHECK (version > 0),
+    answer_text TEXT NOT NULL CHECK (length(trim(answer_text)) > 0),
+    source_ref TEXT NOT NULL CHECK (length(trim(source_ref)) > 0),
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled')),
+    approved_by TEXT NOT NULL CHECK (length(trim(approved_by)) > 0),
+    approved_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (faq_key, version)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_faq_entries_one_active_key
+ON faq_entries (faq_key) WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_faq_entries_key_version
+ON faq_entries (faq_key, version DESC);
+
+CREATE TABLE IF NOT EXISTS faq_resolutions (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    classification_result_id TEXT NOT NULL UNIQUE,
+    faq_entry_id TEXT,
+    status TEXT NOT NULL CHECK (status IN ('resolved', 'supervisor_required')),
+    reason_code TEXT NOT NULL CHECK (
+        reason_code IN (
+            'approved_entry',
+            'entry_not_found',
+            'entry_disabled',
+            'invalid_faq_key'
+        )
+    ),
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
+    FOREIGN KEY (classification_result_id) REFERENCES classification_results(id) ON DELETE CASCADE,
+    FOREIGN KEY (faq_entry_id) REFERENCES faq_entries(id),
+    CHECK (
+        (status = 'resolved' AND reason_code = 'approved_entry' AND faq_entry_id IS NOT NULL)
+        OR
+        (status = 'supervisor_required' AND reason_code != 'approved_entry' AND faq_entry_id IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_faq_resolutions_status
+ON faq_resolutions (status, created_at);
 """

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -142,7 +142,11 @@ CREATE TABLE IF NOT EXISTS faq_resolutions (
     CHECK (
         (status = 'resolved' AND reason_code = 'approved_entry' AND faq_entry_id IS NOT NULL)
         OR
-        (status = 'supervisor_required' AND reason_code != 'approved_entry' AND faq_entry_id IS NULL)
+        (
+            status = 'supervisor_required'
+            AND reason_code != 'approved_entry'
+            AND faq_entry_id IS NULL
+        )
     )
 );
 

--- a/app/services/faq.py
+++ b/app/services/faq.py
@@ -1,0 +1,114 @@
+"""Approved FAQ resolution after durable semantic classification."""
+
+from __future__ import annotations
+
+from app.domain.classification import ClassificationRoute
+from app.domain.faq import (
+    FAQResolutionReason,
+    FAQResolutionResult,
+    FAQResolutionStatus,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+
+
+class FAQNotEligible(RuntimeError):
+    """Raised when FAQ resolution is attempted for a non-FAQ classification."""
+
+
+class FAQService:
+    """Resolve exact FAQ keys against explicitly approved active entries only."""
+
+    def __init__(
+        self,
+        *,
+        classifications: ClassificationRepository,
+        faqs: FAQRepository,
+    ) -> None:
+        self.classifications = classifications
+        self.faqs = faqs
+
+    def resolve(self, event_id: str) -> FAQResolutionResult:
+        """Resolve one classified FAQ event without generation or fuzzy lookup."""
+
+        classification = self.classifications.get_for_event(event_id)
+        if classification is None or classification.route is not ClassificationRoute.FAQ:
+            raise FAQNotEligible("FAQ resolution requires a durable FAQ classification")
+
+        existing = self.faqs.get_resolution(event_id)
+        if existing is not None:
+            entry = (
+                self.faqs.get_entry(existing.faq_entry_id)
+                if existing.faq_entry_id is not None
+                else None
+            )
+            return FAQResolutionResult(resolution=existing, entry=entry)
+
+        faq_key = classification.faq_key
+        if faq_key is None:
+            resolution = self.faqs.create_resolution(
+                event_id=event_id,
+                classification_result_id=classification.id,
+                status=FAQResolutionStatus.SUPERVISOR_REQUIRED,
+                reason=FAQResolutionReason.INVALID_FAQ_KEY,
+                faq_entry_id=None,
+            )
+            return FAQResolutionResult(resolution=resolution, entry=None)
+
+        try:
+            active = self.faqs.get_active(faq_key)
+        except ValueError:
+            resolution = self.faqs.create_resolution(
+                event_id=event_id,
+                classification_result_id=classification.id,
+                status=FAQResolutionStatus.SUPERVISOR_REQUIRED,
+                reason=FAQResolutionReason.INVALID_FAQ_KEY,
+                faq_entry_id=None,
+            )
+            return FAQResolutionResult(resolution=resolution, entry=None)
+
+        if active is None:
+            try:
+                historical_exists = self.faqs.has_versions(faq_key)
+            except ValueError:
+                historical_exists = False
+            reason = (
+                FAQResolutionReason.ENTRY_DISABLED
+                if historical_exists
+                else FAQResolutionReason.ENTRY_NOT_FOUND
+            )
+            resolution = self.faqs.create_resolution(
+                event_id=event_id,
+                classification_result_id=classification.id,
+                status=FAQResolutionStatus.SUPERVISOR_REQUIRED,
+                reason=reason,
+                faq_entry_id=None,
+            )
+            return FAQResolutionResult(resolution=resolution, entry=None)
+
+        try:
+            resolution = self.faqs.create_resolution(
+                event_id=event_id,
+                classification_result_id=classification.id,
+                status=FAQResolutionStatus.RESOLVED,
+                reason=FAQResolutionReason.APPROVED_ENTRY,
+                faq_entry_id=active.id,
+            )
+        except ValueError as exc:
+            if "still be active" not in str(exc):
+                raise
+            resolution = self.faqs.create_resolution(
+                event_id=event_id,
+                classification_result_id=classification.id,
+                status=FAQResolutionStatus.SUPERVISOR_REQUIRED,
+                reason=FAQResolutionReason.ENTRY_DISABLED,
+                faq_entry_id=None,
+            )
+            return FAQResolutionResult(resolution=resolution, entry=None)
+
+        winner_entry = (
+            self.faqs.get_entry(resolution.faq_entry_id)
+            if resolution.faq_entry_id is not None
+            else None
+        )
+        return FAQResolutionResult(resolution=resolution, entry=winner_entry)

--- a/prompts/04_PHASE4_APPROVED_FAQ.md
+++ b/prompts/04_PHASE4_APPROVED_FAQ.md
@@ -1,0 +1,101 @@
+# Execution Prompt — Phase 4: Approved FAQ Store & Resolution Engine
+
+Implement GitHub Issue #12 on branch `phase/04-approved-faq`, stacked on the Phase 3 classification head.
+
+## Execution profile
+
+- Executor class: coding agent / repository producer.
+- Preferred executor when available: Codex-class coding agent.
+- Prompt pattern: immutable/versioned evidence, exact-key lookup, explicit eligibility gates, fail-closed resolution, exhaustive regression tests.
+- Product truth and safety invariants do not vary with executor model.
+
+## Objective
+
+Resolve a durable `FAQ` classification to answer text only by exact lookup of an explicitly approved, active, versioned FAQ entry. The classifier never supplies answer text.
+
+## Hard constraints
+
+1. No generated FAQ answer and no free-text model fallback.
+2. No fuzzy/substitute key lookup.
+3. No real production FAQ seed data in this phase.
+4. FAQ entries are operational/non-fatwa answers only; religious rulings must remain outside this engine.
+5. Missing, disabled, or invalid FAQ key fails closed to a supervisor-required resolution state.
+6. No publishing and no live external API calls.
+7. Persist exact provenance/version linkage for every successful FAQ resolution.
+8. One durable resolution per event; duplicate/racing workers converge on one result.
+9. No credentials, production logs, raw provider responses, or user payload copies.
+
+## Store contract
+
+Use a durable `faq_entries` store with immutable version rows. Include at least:
+
+- id
+- faq_key
+- version > 0
+- answer_text
+- source_ref
+- status: active/disabled
+- approved_by
+- approved_at UTC
+- created_at UTC
+- UNIQUE(faq_key, version)
+- at most one active version per faq_key
+
+Adding a new version is a deliberate repository operation. Do not update historical answer text in place.
+
+## Resolution contract
+
+Persist one `faq_resolutions` row per event, linked to:
+
+- event_id
+- classification_result_id
+- exact faq_entry_id
+- status: resolved / supervisor_required
+- reason code
+- created_at UTC
+
+A successful resolution returns answer text from the linked approved entry. A failed resolution returns no answer text.
+
+## Eligibility
+
+Resolution requires a durable classification result for the event.
+
+- route != FAQ -> ineligible, no resolution row
+- route FAQ + missing/invalid key -> supervisor_required
+- exact active approved entry exists -> resolved
+- key absent or only disabled versions exist -> supervisor_required
+
+## Safety note
+
+The FAQ engine is not a religious-answer system. This phase cannot itself determine religious permissibility and must rely on the upstream classification safety gate. No production FAQ content is seeded here.
+
+## Tests
+
+Prove at least:
+
+1. exact active key resolves approved answer.
+2. missing key -> supervisor_required, no answer.
+3. disabled key -> supervisor_required, no answer.
+4. no fuzzy/substitute match.
+5. non-FAQ classification is ineligible.
+6. entry provenance/version are traceable.
+7. historical versions remain unchanged when a new version is added.
+8. at most one active version per key.
+9. duplicate sequential resolution returns one durable resolution.
+10. concurrent duplicate resolution produces one row.
+11. all four platforms use the same FAQ resolution semantics.
+12. foreign keys are enforced.
+13. no production seed entries exist by default.
+14. prior phase tests remain green.
+
+## Quality gates
+
+```bash
+ruff check app tests
+mypy app
+pytest
+```
+
+## Promotion gate
+
+This is a stacked phase. Prior phases require canonical closure, and this phase requires CI PASS plus independent review before promotion.

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.faq import (
+    FAQEntryStatus,
+    FAQResolutionReason,
+    FAQResolutionStatus,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.faq import FAQNotEligible, FAQService
+from app.services.ingestion import IngestionService
+
+
+def _build(
+    tmp_path: Path,
+) -> tuple[
+    SQLiteDatabase,
+    DurableRepository,
+    ClassificationRepository,
+    FAQRepository,
+    FAQService,
+]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    events = DurableRepository(database)
+    classifications = ClassificationRepository(database)
+    faqs = FAQRepository(database)
+    service = FAQService(classifications=classifications, faqs=faqs)
+    return database, events, classifications, faqs, service
+
+
+def _event(
+    events: DurableRepository,
+    *,
+    key: str,
+    platform: Platform = Platform.FACEBOOK,
+) -> str:
+    return IngestionService(events).ingest_event(
+        NormalizedInboundEvent(
+            platform=platform,
+            external_event_key=key,
+            text="سؤال تشغيلي تجريبي",
+        )
+    ).event.id
+
+
+def _faq_classification(
+    classifications: ClassificationRepository,
+    *,
+    event_id: str,
+    faq_key: str,
+) -> str:
+    result = classifications.create_for_event(
+        event_id=event_id,
+        decision=ClassificationDecision(
+            route=ClassificationRoute.FAQ,
+            reasons=(ClassificationReason.CONFIDENT_FAQ,),
+            faq_key=faq_key,
+        ),
+        religious_possible=False,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    )
+    return result.id
+
+
+def _supervisor_classification(
+    classifications: ClassificationRepository,
+    *,
+    event_id: str,
+) -> str:
+    result = classifications.create_for_event(
+        event_id=event_id,
+        decision=ClassificationDecision(
+            route=ClassificationRoute.SUPERVISOR,
+            reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+        ),
+        religious_possible=False,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    )
+    return result.id
+
+
+def _approved_entry(
+    faqs: FAQRepository,
+    *,
+    key: str = "registration.status",
+    answer: str = "Approved synthetic answer v1",
+    source: str = "fixture://approved/registration/v1",
+) -> str:
+    return faqs.create_version(
+        faq_key=key,
+        answer_text=answer,
+        source_ref=source,
+        approved_by="test-approver",
+        approved_at=datetime(2026, 9, 10, 7, 0, tzinfo=UTC),
+    ).id
+
+
+def test_fresh_database_has_no_seed_faq_entries(tmp_path: Path) -> None:
+    _, _, _, faqs, _ = _build(tmp_path)
+    assert faqs.count_entries() == 0
+
+
+def test_exact_active_key_resolves_only_approved_answer(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="faq-success")
+    classification_id = _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+    entry_id = _approved_entry(faqs)
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.status is FAQResolutionStatus.RESOLVED
+    assert result.resolution.reason is FAQResolutionReason.APPROVED_ENTRY
+    assert result.resolution.classification_result_id == classification_id
+    assert result.resolution.faq_entry_id == entry_id
+    assert result.entry is not None
+    assert result.entry.version == 1
+    assert result.entry.source_ref == "fixture://approved/registration/v1"
+    assert result.answer_text == "Approved synthetic answer v1"
+
+
+def test_missing_key_requires_supervisor_and_has_no_answer(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _event(events, key="faq-missing")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="missing.key",
+    )
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.status is FAQResolutionStatus.SUPERVISOR_REQUIRED
+    assert result.resolution.reason is FAQResolutionReason.ENTRY_NOT_FOUND
+    assert result.resolution.faq_entry_id is None
+    assert result.answer_text is None
+
+
+def test_disabled_key_requires_supervisor_and_has_no_answer(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="faq-disabled")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+    _approved_entry(faqs)
+    disabled = faqs.disable_active("registration.status")
+    assert disabled is not None
+    assert disabled.status is FAQEntryStatus.DISABLED
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.status is FAQResolutionStatus.SUPERVISOR_REQUIRED
+    assert result.resolution.reason is FAQResolutionReason.ENTRY_DISABLED
+    assert result.answer_text is None
+
+
+def test_exact_lookup_never_fuzzy_matches_similar_key(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    _approved_entry(faqs, key="registration.status")
+    event_id = _event(events, key="faq-exact-only")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration",
+    )
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.reason is FAQResolutionReason.ENTRY_NOT_FOUND
+    assert result.answer_text is None
+
+
+def test_non_faq_classification_is_ineligible(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="not-faq")
+    _supervisor_classification(classifications, event_id=event_id)
+
+    with pytest.raises(FAQNotEligible, match="durable FAQ classification"):
+        service.resolve(event_id)
+
+    assert faqs.count_resolutions() == 0
+
+
+def test_invalid_faq_key_requires_supervisor_without_substitution(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    _approved_entry(faqs, key="registration.status")
+    event_id = _event(events, key="invalid-faq-key")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration status",
+    )
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.status is FAQResolutionStatus.SUPERVISOR_REQUIRED
+    assert result.resolution.reason is FAQResolutionReason.INVALID_FAQ_KEY
+    assert result.answer_text is None
+
+
+def test_new_version_preserves_historical_content_and_becomes_only_active(
+    tmp_path: Path,
+) -> None:
+    _, _, _, faqs, _ = _build(tmp_path)
+    first = faqs.create_version(
+        faq_key="registration.status",
+        answer_text="Synthetic answer v1",
+        source_ref="fixture://v1",
+        approved_by="approver-a",
+        approved_at=datetime(2026, 9, 10, 7, 0, tzinfo=UTC),
+    )
+    second = faqs.create_version(
+        faq_key="registration.status",
+        answer_text="Synthetic answer v2",
+        source_ref="fixture://v2",
+        approved_by="approver-b",
+        approved_at=datetime(2026, 9, 10, 8, 0, tzinfo=UTC),
+    )
+
+    versions = faqs.list_versions("registration.status")
+
+    assert [entry.version for entry in versions] == [1, 2]
+    assert versions[0].id == first.id
+    assert versions[0].answer_text == "Synthetic answer v1"
+    assert versions[0].source_ref == "fixture://v1"
+    assert versions[0].status is FAQEntryStatus.DISABLED
+    assert versions[1].id == second.id
+    assert versions[1].answer_text == "Synthetic answer v2"
+    assert versions[1].status is FAQEntryStatus.ACTIVE
+    assert sum(entry.status is FAQEntryStatus.ACTIVE for entry in versions) == 1
+
+
+def test_resolved_answer_becomes_unavailable_after_entry_revocation(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="faq-revoked-after-resolution")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+    _approved_entry(faqs)
+
+    first = service.resolve(event_id)
+    assert first.answer_text == "Approved synthetic answer v1"
+
+    faqs.disable_active("registration.status")
+    second = service.resolve(event_id)
+
+    assert second.resolution.id == first.resolution.id
+    assert second.entry is not None
+    assert second.entry.status is FAQEntryStatus.DISABLED
+    assert second.answer_text is None
+
+
+def test_duplicate_resolution_reuses_one_durable_row(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="faq-duplicate")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+    _approved_entry(faqs)
+
+    first = service.resolve(event_id)
+    second = service.resolve(event_id)
+
+    assert first.resolution.id == second.resolution.id
+    assert faqs.count_resolutions() == 1
+
+
+def test_concurrent_duplicate_resolution_creates_one_row(tmp_path: Path) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    event_id = _event(events, key="faq-race")
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+    _approved_entry(faqs)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(lambda _: service.resolve(event_id).resolution.id, range(20)))
+
+    assert len(set(ids)) == 1
+    assert faqs.count_resolutions() == 1
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_share_exact_faq_resolution_semantics(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    _, events, classifications, faqs, service = _build(tmp_path)
+    _approved_entry(faqs)
+    event_id = _event(events, key=f"faq-{platform.value}", platform=platform)
+    _faq_classification(
+        classifications,
+        event_id=event_id,
+        faq_key="registration.status",
+    )
+
+    result = service.resolve(event_id)
+
+    assert result.resolution.status is FAQResolutionStatus.RESOLVED
+    assert result.answer_text == "Approved synthetic answer v1"
+
+
+def test_faq_resolution_foreign_keys_are_enforced(tmp_path: Path) -> None:
+    database, _, _, _, _ = _build(tmp_path)
+
+    with database.connect() as connection:
+        with pytest.raises(Exception):
+            connection.execute(
+                """
+                INSERT INTO faq_resolutions (
+                    id, event_id, classification_result_id, faq_entry_id,
+                    status, reason_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "bad-resolution",
+                    "missing-event",
+                    "missing-classification",
+                    None,
+                    "supervisor_required",
+                    "entry_not_found",
+                    "2026-09-10T07:00:00+00:00",
+                ),
+            )

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
@@ -333,22 +334,21 @@ def test_all_v1_platforms_share_exact_faq_resolution_semantics(
 def test_faq_resolution_foreign_keys_are_enforced(tmp_path: Path) -> None:
     database, _, _, _, _ = _build(tmp_path)
 
-    with database.connect() as connection:
-        with pytest.raises(Exception):
-            connection.execute(
-                """
-                INSERT INTO faq_resolutions (
-                    id, event_id, classification_result_id, faq_entry_id,
-                    status, reason_code, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    "bad-resolution",
-                    "missing-event",
-                    "missing-classification",
-                    None,
-                    "supervisor_required",
-                    "entry_not_found",
-                    "2026-09-10T07:00:00+00:00",
-                ),
-            )
+    with database.connect() as connection, pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            INSERT INTO faq_resolutions (
+                id, event_id, classification_result_id, faq_entry_id,
+                status, reason_code, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "bad-resolution",
+                "missing-event",
+                "missing-classification",
+                None,
+                "supervisor_required",
+                "entry_not_found",
+                "2026-09-10T07:00:00+00:00",
+            ),
+        )


### PR DESCRIPTION
## Summary

Implements Issue #12 as a stacked Phase 4 change above Classification.

### Added
- versioned immutable approved FAQ entries
- exact-key lookup only; no fuzzy substitution
- approval provenance (`approved_by`, `approved_at`, `source_ref`)
- at most one active FAQ version per key
- durable FAQ resolution linked to exact classification result and exact entry version
- idempotent/concurrent resolution safety
- supervisor-required fail-closed outcomes for missing/disabled/invalid keys
- no generated fallback answer
- revocation safety: a previously resolved entry no longer exposes answer text once disabled
- foreign-key and schema integrity tests

### Safety
- no real FAQ production seed data
- no live APIs
- no publishing
- no religious/fatwa answers in FAQ
- classifier supplies key only, never answer text

### Validation
GitHub Actions run `34451106973` on head `beb7b01062430c0fc35854d45d1d5293c1e32e3a`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/03-classification`, not `main`. Prior phase reviews/promotions remain prerequisites, and this phase requires its own independent review before promotion.