### PR TITLE
Phase 5 — Durable Telegram Supervisor Workflow

### DIFF
--- a/app/adapters/contracts.py
+++ b/app/adapters/contracts.py
@@ -6,6 +6,7 @@ from typing import Protocol
 
 from app.domain.classification import ClassificationAssessment, ClassificationRequest
 from app.domain.moderation import ModerationAssessment, ModerationRequest
+from app.domain.supervisor import SupervisorDispatchRequest
 
 
 class InboundCollector(Protocol):
@@ -57,4 +58,17 @@ class ClassificationAdapter(Protocol):
 
     async def classify(self, request: ClassificationRequest) -> ClassificationAssessment:
         """Return structured routing evidence; never answer the user."""
+        ...
+
+
+class SupervisorTransportAdapter(Protocol):
+    """Provider-neutral boundary for dispatching one human escalation."""
+
+    @property
+    def name(self) -> str:
+        """Stable transport identifier suitable for audit metadata."""
+        ...
+
+    async def dispatch(self, request: SupervisorDispatchRequest) -> str:
+        """Dispatch an escalation and return an external conversation/thread id."""
         ...

--- a/app/domain/supervisor.py
+++ b/app/domain/supervisor.py
@@ -1,0 +1,61 @@
+"""Domain models for durable human-supervisor escalation and response handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class SupervisorEscalationStatus(StrEnum):
+    """Lifecycle for one durable human escalation."""
+
+    PENDING_DISPATCH = "pending_dispatch"
+    AWAITING_RESPONSE = "awaiting_response"
+    RESPONDED = "responded"
+    CANCELLED = "cancelled"
+
+
+class SupervisorEscalationSource(StrEnum):
+    """Evidence source that made an event eligible for supervisor handling."""
+
+    CLASSIFICATION = "classification"
+    FAQ_RESOLUTION = "faq_resolution"
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorEscalation:
+    """One durable escalation linked to exact routing evidence."""
+
+    id: str
+    event_id: str
+    source: SupervisorEscalationSource
+    source_result_id: str
+    status: SupervisorEscalationStatus
+    dispatch_attempt_count: int
+    external_thread_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorResponse:
+    """One accepted human response for an escalation."""
+
+    id: str
+    escalation_id: str
+    external_response_key: str
+    supervisor_ref: str
+    text: str
+    received_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorDispatchRequest:
+    """Minimal provider-neutral payload required to notify a supervisor."""
+
+    escalation_id: str
+    event_id: str
+    platform: str
+    text: str | None
+    correlation_id: str

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -3,7 +3,9 @@
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS inbound_events (
     id TEXT PRIMARY KEY,
-    platform TEXT NOT NULL CHECK (platform IN ('facebook', 'instagram', 'telegram', 'youtube')),
+    platform TEXT NOT NULL CHECK (
+        platform IN ('facebook', 'instagram', 'telegram', 'youtube')
+    ),
     external_event_key TEXT NOT NULL,
     external_event_id TEXT,
     external_comment_id TEXT,
@@ -51,7 +53,9 @@ ON processing_attempts (event_id, attempt_number);
 CREATE TABLE IF NOT EXISTS outbound_actions (
     id TEXT PRIMARY KEY,
     event_id TEXT NOT NULL,
-    platform TEXT NOT NULL CHECK (platform IN ('facebook', 'instagram', 'telegram', 'youtube')),
+    platform TEXT NOT NULL CHECK (
+        platform IN ('facebook', 'instagram', 'telegram', 'youtube')
+    ),
     action_type TEXT NOT NULL,
     idempotency_key TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL,
@@ -74,7 +78,9 @@ CREATE TABLE IF NOT EXISTS moderation_results (
     categories_json TEXT NOT NULL,
     adapter_name TEXT NOT NULL,
     adapter_version TEXT NOT NULL,
-    confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    confidence REAL CHECK (
+        confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)
+    ),
     created_at TEXT NOT NULL,
     FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE
 );
@@ -91,12 +97,17 @@ CREATE TABLE IF NOT EXISTS classification_results (
     religious_possible INTEGER CHECK (
         religious_possible IS NULL OR religious_possible IN (0, 1)
     ),
-    confidence REAL CHECK (confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)),
+    confidence REAL CHECK (
+        confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)
+    ),
     adapter_name TEXT NOT NULL,
     adapter_version TEXT NOT NULL,
     created_at TEXT NOT NULL,
     FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
-    CHECK ((route = 'FAQ' AND faq_key IS NOT NULL) OR (route != 'FAQ' AND faq_key IS NULL))
+    CHECK (
+        (route = 'FAQ' AND faq_key IS NOT NULL)
+        OR (route != 'FAQ' AND faq_key IS NULL)
+    )
 );
 
 CREATE INDEX IF NOT EXISTS idx_classification_results_route
@@ -126,7 +137,9 @@ CREATE TABLE IF NOT EXISTS faq_resolutions (
     event_id TEXT NOT NULL UNIQUE,
     classification_result_id TEXT NOT NULL UNIQUE,
     faq_entry_id TEXT,
-    status TEXT NOT NULL CHECK (status IN ('resolved', 'supervisor_required')),
+    status TEXT NOT NULL CHECK (
+        status IN ('resolved', 'supervisor_required')
+    ),
     reason_code TEXT NOT NULL CHECK (
         reason_code IN (
             'approved_entry',
@@ -137,10 +150,15 @@ CREATE TABLE IF NOT EXISTS faq_resolutions (
     ),
     created_at TEXT NOT NULL,
     FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
-    FOREIGN KEY (classification_result_id) REFERENCES classification_results(id) ON DELETE CASCADE,
+    FOREIGN KEY (classification_result_id)
+        REFERENCES classification_results(id) ON DELETE CASCADE,
     FOREIGN KEY (faq_entry_id) REFERENCES faq_entries(id),
     CHECK (
-        (status = 'resolved' AND reason_code = 'approved_entry' AND faq_entry_id IS NOT NULL)
+        (
+            status = 'resolved'
+            AND reason_code = 'approved_entry'
+            AND faq_entry_id IS NOT NULL
+        )
         OR
         (
             status = 'supervisor_required'
@@ -152,4 +170,68 @@ CREATE TABLE IF NOT EXISTS faq_resolutions (
 
 CREATE INDEX IF NOT EXISTS idx_faq_resolutions_status
 ON faq_resolutions (status, created_at);
+
+CREATE TABLE IF NOT EXISTS supervisor_escalations (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    source TEXT NOT NULL CHECK (
+        source IN ('classification', 'faq_resolution')
+    ),
+    classification_result_id TEXT,
+    faq_resolution_id TEXT,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending_dispatch',
+            'awaiting_response',
+            'responded',
+            'cancelled'
+        )
+    ),
+    dispatch_attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (
+        dispatch_attempt_count >= 0
+    ),
+    transport_name TEXT,
+    external_thread_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
+    FOREIGN KEY (classification_result_id)
+        REFERENCES classification_results(id) ON DELETE CASCADE,
+    FOREIGN KEY (faq_resolution_id)
+        REFERENCES faq_resolutions(id) ON DELETE CASCADE,
+    CHECK (
+        (
+            source = 'classification'
+            AND classification_result_id IS NOT NULL
+            AND faq_resolution_id IS NULL
+        )
+        OR
+        (
+            source = 'faq_resolution'
+            AND classification_result_id IS NULL
+            AND faq_resolution_id IS NOT NULL
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_supervisor_external_thread
+ON supervisor_escalations (external_thread_id)
+WHERE external_thread_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_supervisor_escalations_status
+ON supervisor_escalations (status, created_at);
+
+CREATE TABLE IF NOT EXISTS supervisor_responses (
+    id TEXT PRIMARY KEY,
+    escalation_id TEXT NOT NULL UNIQUE,
+    external_response_key TEXT NOT NULL UNIQUE,
+    supervisor_ref TEXT NOT NULL CHECK (length(trim(supervisor_ref)) > 0),
+    response_text TEXT NOT NULL CHECK (length(trim(response_text)) > 0),
+    received_at TEXT NOT NULL,
+    FOREIGN KEY (escalation_id)
+        REFERENCES supervisor_escalations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_supervisor_responses_received
+ON supervisor_responses (received_at);
 """

--- a/app/persistence/supervisor_repository.py
+++ b/app/persistence/supervisor_repository.py
@@ -1,0 +1,521 @@
+"""SQLite repository for human-supervisor escalations and accepted responses."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.supervisor import (
+    SupervisorEscalation,
+    SupervisorEscalationSource,
+    SupervisorEscalationStatus,
+    SupervisorResponse,
+)
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+_MAX_TRANSPORT_NAME = 80
+_MAX_EXTERNAL_ID = 256
+_MAX_SUPERVISOR_REF = 128
+_MAX_RESPONSE_TEXT = 8000
+
+
+class SupervisorEscalationConflict(RuntimeError):
+    """Raised when one event is bound to contradictory escalation evidence."""
+
+
+class SupervisorResponseConflict(RuntimeError):
+    """Raised when response idempotency semantics conflict."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _bounded(value: str, *, field: str, maximum: int) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if len(normalized) > maximum:
+        raise ValueError(f"{field} must be at most {maximum} characters")
+    return normalized
+
+
+def _compact(value: str, *, field: str, maximum: int) -> str:
+    normalized = _bounded(value, field=field, maximum=maximum)
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field} must be a compact identifier")
+    return normalized
+
+
+def _escalation_from_row(row: sqlite3.Row) -> SupervisorEscalation:
+    source = SupervisorEscalationSource(str(row["source"]))
+    source_result_id = (
+        str(row["classification_result_id"])
+        if source is SupervisorEscalationSource.CLASSIFICATION
+        else str(row["faq_resolution_id"])
+    )
+    return SupervisorEscalation(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        source=source,
+        source_result_id=source_result_id,
+        status=SupervisorEscalationStatus(str(row["status"])),
+        dispatch_attempt_count=int(row["dispatch_attempt_count"]),
+        external_thread_id=(
+            str(row["external_thread_id"])
+            if row["external_thread_id"] is not None
+            else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+        updated_at=_from_timestamp(str(row["updated_at"])),
+    )
+
+
+def _response_from_row(row: sqlite3.Row) -> SupervisorResponse:
+    return SupervisorResponse(
+        id=str(row["id"]),
+        escalation_id=str(row["escalation_id"]),
+        external_response_key=str(row["external_response_key"]),
+        supervisor_ref=str(row["supervisor_ref"]),
+        text=str(row["response_text"]),
+        received_at=_from_timestamp(str(row["received_at"])),
+    )
+
+
+class SupervisorRepository:
+    """Durable state boundary for human escalation workflow."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def get_for_event(self, event_id: str) -> SupervisorEscalation | None:
+        """Return one escalation for an event, if it exists."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _escalation_from_row(row) if row is not None else None
+
+    def count_escalations(self) -> int:
+        """Return the number of durable escalations."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) AS count FROM supervisor_escalations"
+            ).fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def create_from_classification(
+        self,
+        *,
+        event_id: str,
+        classification_result_id: str,
+    ) -> SupervisorEscalation:
+        """Create an escalation for an explicit SUPERVISOR classification."""
+
+        return self._create(
+            event_id=event_id,
+            source=SupervisorEscalationSource.CLASSIFICATION,
+            source_result_id=classification_result_id,
+        )
+
+    def create_from_faq_resolution(
+        self,
+        *,
+        event_id: str,
+        faq_resolution_id: str,
+    ) -> SupervisorEscalation:
+        """Create an escalation for a supervisor-required FAQ resolution."""
+
+        return self._create(
+            event_id=event_id,
+            source=SupervisorEscalationSource.FAQ_RESOLUTION,
+            source_result_id=faq_resolution_id,
+        )
+
+    def _create(
+        self,
+        *,
+        event_id: str,
+        source: SupervisorEscalationSource,
+        source_result_id: str,
+    ) -> SupervisorEscalation:
+        escalation_id = str(uuid4())
+        now = _utc_now()
+        classification_id: str | None = None
+        faq_resolution_id: str | None = None
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event_exists = connection.execute(
+                "SELECT 1 FROM inbound_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if event_exists is None:
+                connection.rollback()
+                raise EventNotFound(event_id)
+
+            if source is SupervisorEscalationSource.CLASSIFICATION:
+                evidence = connection.execute(
+                    "SELECT event_id, route FROM classification_results WHERE id = ?",
+                    (source_result_id,),
+                ).fetchone()
+                if (
+                    evidence is None
+                    or str(evidence["event_id"]) != event_id
+                    or str(evidence["route"]) != "SUPERVISOR"
+                ):
+                    connection.rollback()
+                    raise ValueError("classification is not eligible for supervisor escalation")
+                classification_id = source_result_id
+            else:
+                evidence = connection.execute(
+                    "SELECT event_id, status FROM faq_resolutions WHERE id = ?",
+                    (source_result_id,),
+                ).fetchone()
+                if (
+                    evidence is None
+                    or str(evidence["event_id"]) != event_id
+                    or str(evidence["status"]) != "supervisor_required"
+                ):
+                    connection.rollback()
+                    raise ValueError("FAQ resolution is not eligible for supervisor escalation")
+                faq_resolution_id = source_result_id
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO supervisor_escalations (
+                        id, event_id, source, classification_result_id,
+                        faq_resolution_id, status, dispatch_attempt_count,
+                        transport_name, external_thread_id, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        escalation_id,
+                        event_id,
+                        source.value,
+                        classification_id,
+                        faq_resolution_id,
+                        SupervisorEscalationStatus.PENDING_DISPATCH.value,
+                        0,
+                        None,
+                        None,
+                        _to_timestamp(now),
+                        _to_timestamp(now),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM supervisor_escalations WHERE id = ?",
+                    (escalation_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted supervisor escalation could not be reloaded")
+                return _escalation_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM supervisor_escalations WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _escalation_from_row(row)
+                if existing.source is not source or existing.source_result_id != source_result_id:
+                    raise SupervisorEscalationConflict(
+                        "event is already bound to different supervisor evidence"
+                    ) from None
+                return existing
+
+    def record_dispatch_failure(self, escalation_id: str) -> SupervisorEscalation:
+        """Record one failed transport attempt without persisting exception text."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(escalation_id)
+            current = _escalation_from_row(row)
+            if current.status is not SupervisorEscalationStatus.PENDING_DISPATCH:
+                connection.rollback()
+                raise ValueError("only pending escalations may record dispatch failure")
+            now = _utc_now()
+            connection.execute(
+                """
+                UPDATE supervisor_escalations
+                SET dispatch_attempt_count = dispatch_attempt_count + 1,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (_to_timestamp(now), escalation_id),
+            )
+            updated = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("dispatch failure state could not be reloaded")
+        return _escalation_from_row(updated)
+
+    def mark_dispatched(
+        self,
+        escalation_id: str,
+        *,
+        transport_name: str,
+        external_thread_id: str,
+    ) -> SupervisorEscalation:
+        """Record successful transport dispatch and await a human response."""
+
+        transport = _compact(
+            transport_name,
+            field="transport_name",
+            maximum=_MAX_TRANSPORT_NAME,
+        )
+        thread_id = _compact(
+            external_thread_id,
+            field="external_thread_id",
+            maximum=_MAX_EXTERNAL_ID,
+        )
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(escalation_id)
+            current = _escalation_from_row(row)
+            stored_transport = row["transport_name"]
+            stored_thread = row["external_thread_id"]
+            if current.status in {
+                SupervisorEscalationStatus.AWAITING_RESPONSE,
+                SupervisorEscalationStatus.RESPONDED,
+            }:
+                connection.commit()
+                if str(stored_transport) == transport and str(stored_thread) == thread_id:
+                    return current
+                raise SupervisorEscalationConflict(
+                    "escalation is already bound to different transport evidence"
+                )
+            if current.status is not SupervisorEscalationStatus.PENDING_DISPATCH:
+                connection.rollback()
+                raise ValueError("cancelled escalation cannot be dispatched")
+            now = _utc_now()
+            try:
+                connection.execute(
+                    """
+                    UPDATE supervisor_escalations
+                    SET status = ?, dispatch_attempt_count = dispatch_attempt_count + 1,
+                        transport_name = ?, external_thread_id = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        SupervisorEscalationStatus.AWAITING_RESPONSE.value,
+                        transport,
+                        thread_id,
+                        _to_timestamp(now),
+                        escalation_id,
+                    ),
+                )
+                updated = connection.execute(
+                    "SELECT * FROM supervisor_escalations WHERE id = ?",
+                    (escalation_id,),
+                ).fetchone()
+                connection.commit()
+            except sqlite3.IntegrityError as exc:
+                connection.rollback()
+                raise SupervisorEscalationConflict(
+                    "external_thread_id is already bound to another escalation"
+                ) from exc
+        if updated is None:
+            raise RuntimeError("dispatched escalation could not be reloaded")
+        return _escalation_from_row(updated)
+
+    def cancel(self, escalation_id: str) -> SupervisorEscalation:
+        """Cancel a pending or awaiting escalation through an explicit local action."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(escalation_id)
+            current = _escalation_from_row(row)
+            if current.status in {
+                SupervisorEscalationStatus.RESPONDED,
+                SupervisorEscalationStatus.CANCELLED,
+            }:
+                connection.rollback()
+                raise ValueError("responded or cancelled escalation cannot be cancelled")
+            now = _utc_now()
+            connection.execute(
+                "UPDATE supervisor_escalations SET status = ?, updated_at = ? WHERE id = ?",
+                (
+                    SupervisorEscalationStatus.CANCELLED.value,
+                    _to_timestamp(now),
+                    escalation_id,
+                ),
+            )
+            updated = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("cancelled escalation could not be reloaded")
+        return _escalation_from_row(updated)
+
+    def get_response(self, escalation_id: str) -> SupervisorResponse | None:
+        """Return the accepted response for an escalation, if one exists."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM supervisor_responses WHERE escalation_id = ?",
+                (escalation_id,),
+            ).fetchone()
+        return _response_from_row(row) if row is not None else None
+
+    def accept_response(
+        self,
+        escalation_id: str,
+        *,
+        external_response_key: str,
+        supervisor_ref: str,
+        text: str,
+        received_at: datetime,
+    ) -> SupervisorResponse:
+        """Accept exactly one idempotent human response for an awaiting escalation."""
+
+        response_key = _compact(
+            external_response_key,
+            field="external_response_key",
+            maximum=_MAX_EXTERNAL_ID,
+        )
+        supervisor = _compact(
+            supervisor_ref,
+            field="supervisor_ref",
+            maximum=_MAX_SUPERVISOR_REF,
+        )
+        response_text = _bounded(text, field="text", maximum=_MAX_RESPONSE_TEXT)
+        received_timestamp = _to_timestamp(received_at)
+        response_id = str(uuid4())
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            escalation_row = connection.execute(
+                "SELECT * FROM supervisor_escalations WHERE id = ?",
+                (escalation_id,),
+            ).fetchone()
+            if escalation_row is None:
+                connection.rollback()
+                raise LookupError(escalation_id)
+
+            existing_row = connection.execute(
+                """
+                SELECT * FROM supervisor_responses
+                WHERE escalation_id = ? OR external_response_key = ?
+                LIMIT 1
+                """,
+                (escalation_id, response_key),
+            ).fetchone()
+            if existing_row is not None:
+                connection.commit()
+                existing = _response_from_row(existing_row)
+                if (
+                    existing.escalation_id == escalation_id
+                    and existing.external_response_key == response_key
+                    and existing.supervisor_ref == supervisor
+                    and existing.text == response_text
+                ):
+                    return existing
+                raise SupervisorResponseConflict(
+                    "response idempotency key or escalation is already bound differently"
+                )
+
+            escalation = _escalation_from_row(escalation_row)
+            if escalation.status is not SupervisorEscalationStatus.AWAITING_RESPONSE:
+                connection.rollback()
+                raise ValueError("supervisor response requires awaiting_response state")
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO supervisor_responses (
+                        id, escalation_id, external_response_key,
+                        supervisor_ref, response_text, received_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        response_id,
+                        escalation_id,
+                        response_key,
+                        supervisor,
+                        response_text,
+                        received_timestamp,
+                    ),
+                )
+                now = _utc_now()
+                connection.execute(
+                    "UPDATE supervisor_escalations SET status = ?, updated_at = ? WHERE id = ?",
+                    (
+                        SupervisorEscalationStatus.RESPONDED.value,
+                        _to_timestamp(now),
+                        escalation_id,
+                    ),
+                )
+                created = connection.execute(
+                    "SELECT * FROM supervisor_responses WHERE id = ?",
+                    (response_id,),
+                ).fetchone()
+                connection.commit()
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    """
+                    SELECT * FROM supervisor_responses
+                    WHERE escalation_id = ? OR external_response_key = ?
+                    LIMIT 1
+                    """,
+                    (escalation_id, response_key),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _response_from_row(row)
+                if (
+                    existing.escalation_id == escalation_id
+                    and existing.external_response_key == response_key
+                    and existing.supervisor_ref == supervisor
+                    and existing.text == response_text
+                ):
+                    return existing
+                raise SupervisorResponseConflict(
+                    "concurrent response conflicts with accepted response"
+                ) from None
+
+        if created is None:
+            raise RuntimeError("accepted supervisor response could not be reloaded")
+        return _response_from_row(created)

--- a/app/services/supervisor.py
+++ b/app/services/supervisor.py
@@ -1,0 +1,141 @@
+"""Durable supervisor escalation orchestration without live transport side effects."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.domain.classification import ClassificationRoute
+from app.domain.faq import FAQResolutionStatus
+from app.domain.supervisor import (
+    SupervisorDispatchRequest,
+    SupervisorEscalation,
+    SupervisorEscalationSource,
+    SupervisorEscalationStatus,
+    SupervisorResponse,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.supervisor_repository import SupervisorRepository
+
+
+class SupervisorNotEligible(RuntimeError):
+    """Raised when an event has no durable evidence requiring human supervision."""
+
+
+class SupervisorDispatchNotReady(RuntimeError):
+    """Raised when dispatch preparation is requested from an invalid lifecycle state."""
+
+
+class SupervisorService:
+    """Create and advance human escalation state while transport remains external."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        classifications: ClassificationRepository,
+        faqs: FAQRepository,
+        supervisors: SupervisorRepository,
+    ) -> None:
+        self.events = events
+        self.classifications = classifications
+        self.faqs = faqs
+        self.supervisors = supervisors
+
+    def ensure_escalation(self, event_id: str) -> SupervisorEscalation:
+        """Create or return the single durable escalation justified by routing evidence."""
+
+        existing = self.supervisors.get_for_event(event_id)
+        if existing is not None:
+            return existing
+
+        classification = self.classifications.get_for_event(event_id)
+        if classification is None:
+            raise SupervisorNotEligible("supervisor escalation requires classification evidence")
+
+        if classification.route is ClassificationRoute.SUPERVISOR:
+            return self.supervisors.create_from_classification(
+                event_id=event_id,
+                classification_result_id=classification.id,
+            )
+
+        if classification.route is ClassificationRoute.FAQ:
+            resolution = self.faqs.get_resolution(event_id)
+            if (
+                resolution is not None
+                and resolution.status is FAQResolutionStatus.SUPERVISOR_REQUIRED
+            ):
+                return self.supervisors.create_from_faq_resolution(
+                    event_id=event_id,
+                    faq_resolution_id=resolution.id,
+                )
+
+        raise SupervisorNotEligible(
+            "event is neither SUPERVISOR-routed nor supervisor-required FAQ"
+        )
+
+    def prepare_dispatch(self, event_id: str) -> SupervisorDispatchRequest:
+        """Build the minimal transport payload without performing an external call."""
+
+        escalation = self.ensure_escalation(event_id)
+        if escalation.status is not SupervisorEscalationStatus.PENDING_DISPATCH:
+            raise SupervisorDispatchNotReady(
+                "only pending_dispatch escalation may produce a dispatch request"
+            )
+        event = self.events.get_event(event_id)
+        return SupervisorDispatchRequest(
+            escalation_id=escalation.id,
+            event_id=event.id,
+            platform=event.platform.value,
+            text=event.text,
+            correlation_id=event.correlation_id,
+        )
+
+    def record_dispatch_failure(self, event_id: str) -> SupervisorEscalation:
+        """Increment durable attempt metadata without storing raw transport errors."""
+
+        escalation = self.ensure_escalation(event_id)
+        return self.supervisors.record_dispatch_failure(escalation.id)
+
+    def mark_dispatched(
+        self,
+        event_id: str,
+        *,
+        transport_name: str,
+        external_thread_id: str,
+    ) -> SupervisorEscalation:
+        """Record transport success after an adapter returns a stable external id."""
+
+        escalation = self.ensure_escalation(event_id)
+        return self.supervisors.mark_dispatched(
+            escalation.id,
+            transport_name=transport_name,
+            external_thread_id=external_thread_id,
+        )
+
+    def accept_response(
+        self,
+        event_id: str,
+        *,
+        external_response_key: str,
+        supervisor_ref: str,
+        text: str,
+        received_at: datetime,
+    ) -> SupervisorResponse:
+        """Accept one normalized human response for a dispatched escalation."""
+
+        escalation = self.ensure_escalation(event_id)
+        return self.supervisors.accept_response(
+            escalation.id,
+            external_response_key=external_response_key,
+            supervisor_ref=supervisor_ref,
+            text=text,
+            received_at=received_at,
+        )
+
+    def source_for_event(self, event_id: str) -> SupervisorEscalationSource | None:
+        """Expose escalation evidence type for audit/reporting without provider payloads."""
+
+        escalation = self.supervisors.get_for_event(event_id)
+        return escalation.source if escalation is not None else None

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,16 +9,16 @@ V1 is a single Python service that coordinates comment/message handling for Face
 ```text
 Facebook  ─┐
 Instagram ─┤
-Telegram  ─┼─> Collector ─> Persist-First Core ─> Moderation ─> Classification ─┬─> Approved FAQ reply
-YouTube   ─┘                                                                     ├─> Human supervisor
-                                                                                 └─> Fatwa bot bridge
-                                                                                           │
-                                                                                           ▼
-                                                                                 Publishing Dispatcher
-                                                                                           │
-                                                                 ┌─────────────┬───────────┼───────────┐
-                                                                 ▼             ▼           ▼           ▼
-                                                              Facebook      Instagram   Telegram    YouTube
+Telegram  ─┼─> Collector ─> Persist First ─> Moderation ─> Classification ─┬─> FAQ
+YouTube   ─┘                                                                ├─> Supervisor
+                                                                            └─> Fatwa Bridge
+                                                                                     │
+                                                                                     ▼
+                                                                            Publishing Dispatcher
+                                                                                     │
+                                                            ┌────────────┬────────────┼───────────┐
+                                                            ▼            ▼            ▼           ▼
+                                                         Facebook     Instagram    Telegram    YouTube
 ```
 
 ## Boundaries
@@ -35,23 +35,25 @@ Each adapter normalizes platform-specific identifiers and payloads into the shar
 
 ### Durable event boundary
 
-Every accepted inbound event is persisted before moderation, classification, or publishing work begins.
+Every accepted inbound event is persisted before moderation, classification, FAQ resolution, supervisor handling, fatwa routing, or publishing work begins.
 
-The V1 durable core uses SQLite behind repository/service abstractions and contains persistent concerns including:
+The SQLite durable layer contains persistent concerns including:
 
-- `inbound_events`: normalized accepted events and their processing state.
+- `inbound_events`: normalized accepted events and processing state.
 - `processing_attempts`: sanitized attempt history and retry metadata.
 - `outbound_actions`: durable publish intents/results with unique idempotency keys.
-- `moderation_results`: one normalized, auditable moderation routing decision per inbound event.
-- `classification_results`: one normalized, auditable semantic route per eligible inbound event.
+- `moderation_results`: one normalized moderation decision per event.
+- `classification_results`: one normalized semantic route per eligible event.
+- `faq_entries`: immutable versioned approved operational answers.
+- `faq_resolutions`: one exact-key FAQ resolution per classified event.
+- `supervisor_escalations`: one durable human escalation per eligible event.
+- `supervisor_responses`: one accepted human response per escalation.
 
-The uniqueness boundary for inbound work is `(platform, external_event_key)`. The uniqueness boundary for outbound work is `idempotency_key`.
-
-A duplicate inbound delivery must resolve to the original internal event instead of creating a second record. A duplicate outbound intent must not create a second action.
+Inbound uniqueness is `(platform, external_event_key)`. Outbound uniqueness is `idempotency_key`. Duplicate work must resolve to the existing durable record instead of creating a second semantic action.
 
 ### Processing state machine
 
-Core processing state changes are explicit domain transitions rather than arbitrary database updates. V1 includes at least:
+Core event state changes are explicit domain transitions. V1 includes:
 
 - `received`
 - `processing`
@@ -64,103 +66,98 @@ Terminal states do not transition unless a future explicit recovery mechanism is
 
 ### Moderation boundary
 
-Moderation happens after persist-first ingestion and before semantic classification.
+Moderation occurs after persist-first ingestion and before semantic classification.
 
-The moderation design is split into three responsibilities:
+A provider-neutral async `ModerationAdapter` returns normalized evidence only. A deterministic local policy maps the evidence to one routing-only disposition:
 
-1. A provider-neutral async `ModerationAdapter` returns normalized moderation evidence only.
-2. A deterministic local policy maps that evidence to one routing-only disposition.
-3. A durable moderation repository stores one auditable result for the inbound event.
+- `allow_routing`
+- `human_review`
+- `block_routing`
 
-The V1 routing-only dispositions are:
-
-- `allow_routing`: moderation evidence is explicitly safe and sufficiently confident for semantic routing to continue.
-- `human_review`: evidence is missing, uncertain, low-confidence, unsupported, malformed, or the moderation adapter failed.
-- `block_routing`: sufficiently confident unsafe evidence prevents automated semantic routing.
-
-`block_routing` is not an authorization to hide, delete, report, or otherwise mutate external content. External moderation enforcement is outside this phase and requires an explicit later policy and adapter action.
-
-Text/media coverage is fail-closed. If normalized media exists but the adapter did not actually assess it, the event cannot receive `allow_routing`. Likewise, an event with no assessable text or media goes to human review rather than being guessed safe.
-
-Moderation adapter exceptions are converted to a normalized human-review result. Raw exception traces, credentials, authorization headers, provider payloads, and secret-bearing diagnostics are not persisted in `moderation_results`.
-
-The moderation result is idempotent per `event_id`. Duplicate or racing workers resolve to the same persisted result instead of creating multiple moderation rows.
+`block_routing` does not authorize hide/delete/report actions. Missing coverage, low confidence, malformed evidence, contradictory evidence, and adapter failure fail closed toward human review rather than automatic routing.
 
 ### Classification boundary
 
-Semantic classification is eligible only after a durable moderation result explicitly says `allow_routing`. Missing moderation, `human_review`, or `block_routing` prevents the classifier from running.
+Classification runs only after durable `allow_routing` moderation. The async adapter produces routing evidence only; the deterministic local policy is authoritative.
 
-Classification is split into three responsibilities:
-
-1. A provider-neutral async `ClassificationAdapter` returns structured routing evidence only.
-2. A deterministic local `ClassificationPolicy` applies Gheras safety rules and selects the authoritative route.
-3. A durable classification repository stores one normalized result per inbound event.
-
-The only V1 semantic routes are:
+The only V1 routes are:
 
 - `FAQ`
 - `SUPERVISOR`
 - `FATWA`
 
-The adapter does not produce user-facing answer text. Its normalized evidence is limited to routing fields such as proposed route, confidence, whether religious content may be involved, and an optional FAQ key.
+Safety rules include:
 
-The local policy is authoritative. Important fail-closed rules include:
-
-- `religious_possible=true` always forces `FATWA`, even if the adapter proposed FAQ or the event has no classifiable text.
+- `religious_possible=true` always forces `FATWA`.
 - an explicit FATWA proposal remains `FATWA`.
-- low-confidence FAQ candidates become `SUPERVISOR`.
-- FAQ candidates without a valid compact `faq_key` become `SUPERVISOR`.
-- adapter failures and malformed structured evidence become `SUPERVISOR`, never FAQ.
-- content without classifiable text and without a religious signal becomes `SUPERVISOR`.
+- low-confidence FAQ becomes `SUPERVISOR`.
+- FAQ without a valid compact key becomes `SUPERVISOR`.
+- adapter failure/malformed output becomes `SUPERVISOR`.
+- the classifier never generates user-facing answer text or a fatwa.
 
-A `FATWA` route is only a routing decision. It does not contain, create, infer, or publish a religious ruling. The later fatwa bridge remains the only boundary to the existing supervised fatwa system.
+`classification_results` deliberately stores no prompt, chain-of-thought, raw provider response, or answer payload.
 
-`classification_results` stores normalized route evidence and audit metadata only. It deliberately has no answer, prompt, chain-of-thought, raw provider response, or provider payload column.
+### Approved FAQ boundary
 
-The classification result is idempotent per `event_id`. Sequential or racing workers converge on the same persisted result.
+FAQ resolution is eligible only for a durable `FAQ` classification containing an exact key.
 
-### AI adapters
+The model never supplies the answer. Answers come only from `faq_entries`, which are versioned and preserve approval provenance (`approved_by`, `approved_at`, `source_ref`). Historical versions are not rewritten in place, and SQLite permits at most one active version for a key.
 
-Moderation and classification are separate adapters. Classification is routing-only; religious questions must never receive an AI-generated religious answer.
+Resolution is exact-key only; no fuzzy key substitution and no generated fallback are allowed. Missing, disabled, or invalid keys create `supervisor_required` resolution instead of answer text.
 
-### Approved FAQ store
+Each `faq_resolution` links the event and classification to the exact approved entry used. Duplicate/racing workers converge on one resolution. If an entry is later disabled, the historical resolution remains auditable but its answer text is no longer eligible for future publishing.
 
-Operational answers such as schedules, registration information, and links come from an approved store. The classifier may select an intent/key but may not invent the answer.
+### Human supervisor boundary
 
-### Human supervisor workflow
+Human escalation is eligible only when:
 
-Unknown or low-confidence non-religious content is routed to supervisors. Telegram is the V1 supervisor interface, but supervisor transport remains separate from core routing logic.
+1. classification is explicitly `SUPERVISOR`; or
+2. a `FAQ` classification has a durable `supervisor_required` FAQ resolution.
+
+FATWA-routed events and successfully resolved FAQ events are not eligible for this workflow.
+
+Telegram is the intended V1 supervisor transport, but transport is not the source of truth. `supervisor_escalations` and `supervisor_responses` persist workflow state independently of Telegram.
+
+The escalation lifecycle is:
+
+```text
+pending_dispatch -> awaiting_response -> responded
+       │                  │
+       └──────────────> cancelled
+```
+
+The service prepares a minimal normalized dispatch request but does not perform a live Telegram call in Phase 5. Successful external dispatch is recorded only after a transport returns a stable external thread identifier. Failed attempts increment durable attempt metadata without storing raw exception text.
+
+One accepted human response is allowed per escalation. Duplicate identical provider updates are idempotent; reuse of an external response key or escalation with different response semantics fails closed as a conflict. Supervisor responses are human-provided content and are not automatically published by this phase.
 
 ### Fatwa bot bridge
 
-The existing fatwa bot remains a separate system boundary. This service exchanges only the information required to route a question and publish an approved response. Public documentation should not expose unnecessary internal workflow details.
+The existing fatwa bot remains a separate system boundary. Gheras exchanges only the information required to route a question and consume an approved supervised result. Gheras AI must never fabricate or infer a fatwa.
 
 ### Publishing dispatcher
 
-Publishing is separated from classification and response composition. A dispatcher selects the correct adapter for Facebook, Instagram, Telegram, or YouTube and uses durable outbound action records to prevent duplicate publishing.
+Publishing is separated from classification, FAQ resolution, supervisor response handling, and fatwa handling. A later dispatcher selects the correct Facebook/Instagram/Telegram/YouTube adapter and uses durable outbound action records to prevent duplicate publishing.
 
 ## Reliability rules
 
 - Persist first, process later.
 - Inbound platform events are idempotent.
-- Moderation decisions are durable and idempotent per inbound event.
-- Classification decisions are durable and idempotent per eligible inbound event.
+- Moderation, classification, FAQ resolution, and supervisor escalation are durable.
+- Duplicate/racing workers converge on one semantic durable result.
 - Outbound replies/actions are idempotent.
-- Accepted work and processing state survive process restarts.
 - SQLite foreign keys are enabled.
-- WAL mode and a sensible busy timeout are preferred where safe for V1.
-- External API failures must not silently lose accepted work.
-- Low-confidence routing escalates to a human rather than guessing.
-- Possible religious content fails toward the FATWA route rather than an automatic answer.
-- Secrets are supplied through process environment variables and are never committed.
-- Raw external payloads are not blindly persisted; store normalized fields required by the router.
+- WAL mode and busy timeout are enabled where safe.
+- External failure must not silently lose accepted work.
+- Low-confidence or uncertain routing escalates rather than guesses.
+- Possible religious content fails toward FATWA routing, never an AI-generated answer.
+- Secrets come from environment variables and are never committed.
+- Raw external provider payloads are not blindly persisted.
 
 ## Current implementation boundary
 
-Phase 0 established configuration, the HTTP application, adapter interfaces, tests, and CI.
-
-Phase 1 implements the durable core and intentionally contains no real Meta, Telegram, YouTube/Google, OpenAI, or fatwa-bot calls.
-
-Phase 2 adds the mock-first moderation domain, async adapter contract, deterministic fail-closed policy, durable moderation-result repository, and idempotent moderation service. It still performs no live external moderation call and no external hide/delete/report action.
-
-Phase 3 adds the mock-first structured classification domain, async adapter contract, moderation eligibility gate, deterministic religious-safety routing policy, durable classification-result repository, and idempotent classification service. It performs no live model call and creates no user-facing answer or fatwa.
+- Phase 0: application/configuration/CI bootstrap.
+- Phase 1: durable event core, retries, state machine, inbound/outbound idempotency.
+- Phase 2: mock-first fail-closed moderation and durable moderation results.
+- Phase 3: mock-first routing-only classification with religious safety override.
+- Phase 4: versioned approved FAQ store and exact-key durable resolution.
+- Phase 5: durable human supervisor escalation/response workflow and transport contract, with no live Telegram calls.

--- a/prompts/05_PHASE5_SUPERVISOR_WORKFLOW.md
+++ b/prompts/05_PHASE5_SUPERVISOR_WORKFLOW.md
@@ -1,0 +1,45 @@
+# Phase 5 — Durable Supervisor Workflow
+
+## Objective
+
+Implement the V1 human-supervisor workflow after classification/FAQ resolution. Telegram is the intended V1 transport, but this phase is mock-first and must not make live Telegram calls.
+
+## Authoritative eligibility
+
+An event is eligible only when either:
+
+1. its durable classification route is `SUPERVISOR`; or
+2. its durable classification route is `FAQ` and its durable FAQ resolution is `supervisor_required`.
+
+No other event may be escalated by this service.
+
+## Required design
+
+- provider-neutral `SupervisorTransportAdapter` boundary;
+- durable one-per-event escalation record;
+- lifecycle: `pending_dispatch -> awaiting_response -> responded`, with `cancelled` available only through an explicit local action;
+- one accepted durable supervisor response per escalation;
+- duplicate dispatch/response handling must be idempotent;
+- conflicting reuse of response idempotency keys must fail closed;
+- normalized bounded supervisor reply text only; no raw Telegram update payloads;
+- no automatic publication back to Facebook/Instagram/Telegram/YouTube in this phase;
+- no real tokens, secrets, Telegram API calls, or production side effects.
+
+## Persistence
+
+Add durable tables for supervisor escalations and supervisor responses. Preserve exact source evidence linking the escalation to either a classification result or FAQ resolution.
+
+## Safety
+
+- AI must not fabricate a supervisor response.
+- FATWA-routed events are not supervisor-workflow eligible here.
+- FAQ-resolved events are not supervisor-workflow eligible.
+- Telegram transport failure must not mark an escalation as dispatched/responded.
+- Store only identifiers/text required for routing and later publishing.
+
+## Quality gates
+
+- `ruff check app tests`
+- `mypy app`
+- `pytest`
+- independent review before promotion

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.faq import FAQResolutionStatus
+from app.domain.supervisor import (
+    SupervisorEscalationSource,
+    SupervisorEscalationStatus,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.persistence.supervisor_repository import (
+    SupervisorEscalationConflict,
+    SupervisorRepository,
+    SupervisorResponseConflict,
+)
+from app.services.faq import FAQService
+from app.services.ingestion import IngestionService
+from app.services.supervisor import (
+    SupervisorDispatchNotReady,
+    SupervisorNotEligible,
+    SupervisorService,
+)
+
+
+def _build(
+    tmp_path: Path,
+) -> tuple[
+    SQLiteDatabase,
+    DurableRepository,
+    ClassificationRepository,
+    FAQRepository,
+    SupervisorRepository,
+    SupervisorService,
+]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    events = DurableRepository(database)
+    classifications = ClassificationRepository(database)
+    faqs = FAQRepository(database)
+    supervisors = SupervisorRepository(database)
+    service = SupervisorService(
+        events=events,
+        classifications=classifications,
+        faqs=faqs,
+        supervisors=supervisors,
+    )
+    return database, events, classifications, faqs, supervisors, service
+
+
+def _ingest(
+    events: DurableRepository,
+    *,
+    key: str,
+    platform: Platform = Platform.FACEBOOK,
+    text: str | None = "أحتاج مساعدة من المشرف",
+) -> str:
+    return IngestionService(events).ingest_event(
+        NormalizedInboundEvent(
+            platform=platform,
+            external_event_key=key,
+            text=text,
+        )
+    ).event.id
+
+
+def _classify_supervisor(
+    classifications: ClassificationRepository,
+    event_id: str,
+) -> str:
+    result = classifications.create_for_event(
+        event_id=event_id,
+        decision=ClassificationDecision(
+            route=ClassificationRoute.SUPERVISOR,
+            reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+        ),
+        religious_possible=False,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    )
+    return result.id
+
+
+def _classify_fatwa(
+    classifications: ClassificationRepository,
+    event_id: str,
+) -> None:
+    classifications.create_for_event(
+        event_id=event_id,
+        decision=ClassificationDecision(
+            route=ClassificationRoute.FATWA,
+            reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+        ),
+        religious_possible=True,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    )
+
+
+def _classify_faq(
+    classifications: ClassificationRepository,
+    event_id: str,
+    *,
+    faq_key: str,
+) -> None:
+    classifications.create_for_event(
+        event_id=event_id,
+        decision=ClassificationDecision(
+            route=ClassificationRoute.FAQ,
+            reasons=(ClassificationReason.CONFIDENT_FAQ,),
+            faq_key=faq_key,
+        ),
+        religious_possible=False,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    )
+
+
+def test_supervisor_classification_creates_durable_escalation(tmp_path: Path) -> None:
+    _, events, classifications, _, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="supervisor-route")
+    classification_id = _classify_supervisor(classifications, event_id)
+
+    escalation = service.ensure_escalation(event_id)
+
+    assert escalation.source is SupervisorEscalationSource.CLASSIFICATION
+    assert escalation.source_result_id == classification_id
+    assert escalation.status is SupervisorEscalationStatus.PENDING_DISPATCH
+    assert escalation.dispatch_attempt_count == 0
+    assert supervisors.count_escalations() == 1
+
+
+def test_missing_faq_entry_escalates_from_faq_resolution(tmp_path: Path) -> None:
+    _, events, classifications, faqs, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="faq-fallback")
+    _classify_faq(classifications, event_id, faq_key="missing.key")
+    resolution = FAQService(classifications=classifications, faqs=faqs).resolve(event_id)
+    assert resolution.resolution.status is FAQResolutionStatus.SUPERVISOR_REQUIRED
+
+    escalation = service.ensure_escalation(event_id)
+
+    assert escalation.source is SupervisorEscalationSource.FAQ_RESOLUTION
+    assert escalation.source_result_id == resolution.resolution.id
+
+
+def test_fatwa_route_is_not_supervisor_eligible(tmp_path: Path) -> None:
+    _, events, classifications, _, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="fatwa-route", text="ما حكم هذا؟")
+    _classify_fatwa(classifications, event_id)
+
+    with pytest.raises(SupervisorNotEligible):
+        service.ensure_escalation(event_id)
+
+    assert supervisors.count_escalations() == 0
+
+
+def test_resolved_faq_is_not_supervisor_eligible(tmp_path: Path) -> None:
+    _, events, classifications, faqs, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="resolved-faq")
+    _classify_faq(classifications, event_id, faq_key="registration.status")
+    faqs.create_version(
+        faq_key="registration.status",
+        answer_text="التسجيل مفتوح.",
+        source_ref="fixture://approved/registration",
+        approved_by="reviewer-1",
+        approved_at=datetime(2026, 9, 10, 7, 0, tzinfo=UTC),
+    )
+    resolution = FAQService(classifications=classifications, faqs=faqs).resolve(event_id)
+    assert resolution.resolution.status is FAQResolutionStatus.RESOLVED
+
+    with pytest.raises(SupervisorNotEligible):
+        service.ensure_escalation(event_id)
+
+    assert supervisors.count_escalations() == 0
+
+
+def test_prepare_dispatch_returns_minimal_normalized_payload(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(
+        events,
+        key="dispatch-payload",
+        platform=Platform.YOUTUBE,
+        text="أحتاج مشرفًا",
+    )
+    _classify_supervisor(classifications, event_id)
+
+    request = service.prepare_dispatch(event_id)
+
+    assert request.event_id == event_id
+    assert request.platform == "youtube"
+    assert request.text == "أحتاج مشرفًا"
+    assert request.correlation_id
+
+
+def test_dispatch_failure_increments_attempt_without_advancing_state(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-failure")
+    _classify_supervisor(classifications, event_id)
+
+    failed = service.record_dispatch_failure(event_id)
+
+    assert failed.status is SupervisorEscalationStatus.PENDING_DISPATCH
+    assert failed.dispatch_attempt_count == 1
+
+
+def test_successful_dispatch_becomes_awaiting_and_is_idempotent(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-success")
+    _classify_supervisor(classifications, event_id)
+
+    first = service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-100",
+    )
+    second = service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-100",
+    )
+
+    assert first.id == second.id
+    assert first.status is SupervisorEscalationStatus.AWAITING_RESPONSE
+    assert second.dispatch_attempt_count == 1
+
+
+def test_dispatch_cannot_be_rebound_to_different_thread(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-conflict")
+    _classify_supervisor(classifications, event_id)
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-1",
+    )
+
+    with pytest.raises(SupervisorEscalationConflict):
+        service.mark_dispatched(
+            event_id,
+            transport_name="telegram",
+            external_thread_id="thread-2",
+        )
+
+
+def test_response_requires_awaiting_response_state(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="premature-response")
+    _classify_supervisor(classifications, event_id)
+
+    with pytest.raises(ValueError, match="awaiting_response"):
+        service.accept_response(
+            event_id,
+            external_response_key="response-1",
+            supervisor_ref="supervisor-1",
+            text="الرد البشري",
+            received_at=datetime(2026, 9, 10, 7, 10, tzinfo=UTC),
+        )
+
+
+def test_human_response_is_durable_and_duplicate_is_idempotent(tmp_path: Path) -> None:
+    _, events, classifications, _, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="human-response")
+    _classify_supervisor(classifications, event_id)
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-200",
+    )
+
+    first = service.accept_response(
+        event_id,
+        external_response_key="response-200",
+        supervisor_ref="supervisor-1",
+        text="هذا هو الرد المعتمد من المشرف.",
+        received_at=datetime(2026, 9, 10, 7, 15, tzinfo=UTC),
+    )
+    second = service.accept_response(
+        event_id,
+        external_response_key="response-200",
+        supervisor_ref="supervisor-1",
+        text="هذا هو الرد المعتمد من المشرف.",
+        received_at=datetime(2026, 9, 10, 7, 15, tzinfo=UTC),
+    )
+
+    escalation = supervisors.get_for_event(event_id)
+    assert escalation is not None
+    assert escalation.status is SupervisorEscalationStatus.RESPONDED
+    assert first.id == second.id
+    assert first.text == "هذا هو الرد المعتمد من المشرف."
+
+
+def test_second_different_response_fails_closed(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="response-conflict")
+    _classify_supervisor(classifications, event_id)
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-300",
+    )
+    service.accept_response(
+        event_id,
+        external_response_key="response-300",
+        supervisor_ref="supervisor-1",
+        text="الرد الأول",
+        received_at=datetime(2026, 9, 10, 7, 20, tzinfo=UTC),
+    )
+
+    with pytest.raises(SupervisorResponseConflict):
+        service.accept_response(
+            event_id,
+            external_response_key="response-301",
+            supervisor_ref="supervisor-2",
+            text="رد مختلف",
+            received_at=datetime(2026, 9, 10, 7, 21, tzinfo=UTC),
+        )
+
+
+def test_concurrent_duplicate_escalation_creates_one_row(tmp_path: Path) -> None:
+    _, events, classifications, _, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="escalation-race")
+    _classify_supervisor(classifications, event_id)
+
+    def create_once(_: int) -> str:
+        return service.ensure_escalation(event_id).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(create_once, range(20)))
+
+    assert len(set(ids)) == 1
+    assert supervisors.count_escalations() == 1
+
+
+def test_concurrent_duplicate_response_creates_one_response(tmp_path: Path) -> None:
+    _, events, classifications, _, supervisors, service = _build(tmp_path)
+    event_id = _ingest(events, key="response-race")
+    _classify_supervisor(classifications, event_id)
+    escalation = service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-race",
+    )
+
+    def respond_once(_: int) -> str:
+        return service.accept_response(
+            event_id,
+            external_response_key="response-race",
+            supervisor_ref="supervisor-1",
+            text="رد واحد",
+            received_at=datetime(2026, 9, 10, 7, 25, tzinfo=UTC),
+        ).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(respond_once, range(20)))
+
+    assert len(set(ids)) == 1
+    response = supervisors.get_response(escalation.id)
+    assert response is not None
+    assert response.id == ids[0]
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_share_supervisor_semantics(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(
+        events,
+        key=f"supervisor-{platform.value}",
+        platform=platform,
+    )
+    _classify_supervisor(classifications, event_id)
+
+    escalation = service.ensure_escalation(event_id)
+
+    assert escalation.status is SupervisorEscalationStatus.PENDING_DISPATCH
+
+
+def test_dispatch_request_rejected_after_dispatch(tmp_path: Path) -> None:
+    _, events, classifications, _, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-request-state")
+    _classify_supervisor(classifications, event_id)
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id="thread-400",
+    )
+
+    with pytest.raises(SupervisorDispatchNotReady):
+        service.prepare_dispatch(event_id)
+
+
+def test_supervisor_schema_has_no_raw_provider_or_secret_columns(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+
+    with database.connect() as connection:
+        escalation_rows = connection.execute(
+            "PRAGMA table_info(supervisor_escalations)"
+        ).fetchall()
+        response_rows = connection.execute(
+            "PRAGMA table_info(supervisor_responses)"
+        ).fetchall()
+
+    column_names = {
+        str(row["name"]).lower()
+        for row in (*escalation_rows, *response_rows)
+    }
+    forbidden = {"payload", "token", "secret", "authorization", "raw_update"}
+    assert not any(fragment in name for name in column_names for fragment in forbidden)


### PR DESCRIPTION
## Summary

Implements Issue #14 as a stacked Phase 5 change above Approved FAQ.

### Added
- durable `supervisor_escalations` and `supervisor_responses`
- explicit eligibility from SUPERVISOR classification or supervisor-required FAQ resolution
- lifecycle: pending_dispatch -> awaiting_response -> responded, with explicit cancellation
- minimal provider-neutral dispatch request
- durable dispatch attempt count without raw transport errors
- one accepted human response per escalation
- idempotent duplicate response handling
- fail-closed conflicting response and transport evidence
- all four platform events share the same supervisor workflow
- Telegram transport kept outside durable state ownership

### Safety
- no live Telegram call
- no token/secret
- no automatic origin-platform publication
- FATWA-routed and successfully resolved FAQ events are ineligible
- no raw Telegram update payload persistence

### Validation
GitHub Actions run `34451990709` on head `1eb358e7b31cffad1ea4381f7cb7c89c55ad3c9b`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/04-approved-faq`, not `main`. Prior phase reviews/promotions remain prerequisites, and this phase requires its own independent review before promotion.