### PR TITLE
Phase 6 — Mock-First Platform Adapters

### DIFF
--- a/app/adapters/platforms/__init__.py
+++ b/app/adapters/platforms/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-specific platform adapters for Gheras V1."""

--- a/app/adapters/platforms/common.py
+++ b/app/adapters/platforms/common.py
@@ -1,0 +1,52 @@
+"""Shared validation helpers for mock-first provider adapters."""
+
+from __future__ import annotations
+
+_MAX_PROVIDER_ID = 512
+_MAX_REPLY_TEXT = 10000
+
+
+class AdapterPayloadError(ValueError):
+    """Raised when provider data cannot be normalized without guessing."""
+
+
+def required_id(value: str, *, field: str) -> str:
+    """Validate one stable provider identifier without rewriting it."""
+
+    if not isinstance(value, str):
+        raise AdapterPayloadError(f"{field} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise AdapterPayloadError(f"{field} must not be empty")
+    if len(normalized) > _MAX_PROVIDER_ID:
+        raise AdapterPayloadError(f"{field} exceeds maximum identifier length")
+    if any(char.isspace() for char in normalized):
+        raise AdapterPayloadError(f"{field} must not contain whitespace")
+    return normalized
+
+
+def optional_id(value: str | None, *, field: str) -> str | None:
+    """Validate an optional provider identifier."""
+
+    if value is None:
+        return None
+    return required_id(value, field=field)
+
+
+def required_text(value: str, *, field: str = "text") -> str:
+    """Require non-empty text while preserving the provider text verbatim."""
+
+    if not isinstance(value, str):
+        raise AdapterPayloadError(f"{field} must be a string")
+    if not value.strip():
+        raise AdapterPayloadError(f"{field} must not be empty")
+    return value
+
+
+def reply_text(value: str) -> str:
+    """Validate outbound text without semantic rewriting."""
+
+    text = required_text(value, field="reply_text")
+    if len(text) > _MAX_REPLY_TEXT:
+        raise AdapterPayloadError("reply_text exceeds safe adapter boundary")
+    return text

--- a/app/adapters/platforms/facebook.py
+++ b/app/adapters/platforms/facebook.py
@@ -1,0 +1,57 @@
+"""Facebook normalization and injectable reply boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.adapters.platforms.common import optional_id, reply_text, required_id, required_text
+from app.domain.events import NormalizedInboundEvent, Platform
+
+
+@dataclass(frozen=True, slots=True)
+class FacebookCommentDTO:
+    """Validated boundary fields required from a Facebook comment delivery."""
+
+    comment_id: str
+    post_id: str
+    author_id: str
+    text: str
+    event_id: str | None = None
+
+
+class FacebookAdapter:
+    """Pure Facebook-to-domain normalizer."""
+
+    @staticmethod
+    def normalize(comment: FacebookCommentDTO) -> NormalizedInboundEvent:
+        comment_id = required_id(comment.comment_id, field="comment_id")
+        return NormalizedInboundEvent(
+            platform=Platform.FACEBOOK,
+            external_event_key=comment_id,
+            external_event_id=optional_id(comment.event_id, field="event_id"),
+            external_comment_id=comment_id,
+            external_post_id=required_id(comment.post_id, field="post_id"),
+            author_id=required_id(comment.author_id, field="author_id"),
+            text=required_text(comment.text),
+        )
+
+
+class FacebookReplyClient(Protocol):
+    """Injected client boundary; production implementation belongs to live integration."""
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        """Return the created Facebook reply identifier."""
+        ...
+
+
+class FacebookReplyPublisher:
+    """Facebook reply adapter backed only by an injected client."""
+
+    def __init__(self, client: FacebookReplyClient) -> None:
+        self.client = client
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        target = required_id(external_comment_id, field="external_comment_id")
+        result = await self.client.reply_to_comment(target, reply_text(text))
+        return required_id(result, field="external_result_id")

--- a/app/adapters/platforms/instagram.py
+++ b/app/adapters/platforms/instagram.py
@@ -1,0 +1,57 @@
+"""Instagram normalization and injectable reply boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.adapters.platforms.common import optional_id, reply_text, required_id, required_text
+from app.domain.events import NormalizedInboundEvent, Platform
+
+
+@dataclass(frozen=True, slots=True)
+class InstagramCommentDTO:
+    """Validated boundary fields required from an Instagram comment delivery."""
+
+    comment_id: str
+    media_id: str
+    author_id: str
+    text: str
+    event_id: str | None = None
+
+
+class InstagramAdapter:
+    """Pure Instagram-to-domain normalizer."""
+
+    @staticmethod
+    def normalize(comment: InstagramCommentDTO) -> NormalizedInboundEvent:
+        comment_id = required_id(comment.comment_id, field="comment_id")
+        return NormalizedInboundEvent(
+            platform=Platform.INSTAGRAM,
+            external_event_key=comment_id,
+            external_event_id=optional_id(comment.event_id, field="event_id"),
+            external_comment_id=comment_id,
+            external_post_id=required_id(comment.media_id, field="media_id"),
+            author_id=required_id(comment.author_id, field="author_id"),
+            text=required_text(comment.text),
+        )
+
+
+class InstagramReplyClient(Protocol):
+    """Injected client boundary; production implementation belongs to live integration."""
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        """Return the created Instagram reply identifier."""
+        ...
+
+
+class InstagramReplyPublisher:
+    """Instagram reply adapter backed only by an injected client."""
+
+    def __init__(self, client: InstagramReplyClient) -> None:
+        self.client = client
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        target = required_id(external_comment_id, field="external_comment_id")
+        result = await self.client.reply_to_comment(target, reply_text(text))
+        return required_id(result, field="external_result_id")

--- a/app/adapters/platforms/telegram.py
+++ b/app/adapters/platforms/telegram.py
@@ -1,0 +1,95 @@
+"""Telegram normalization, reply, and supervisor transport boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.adapters.platforms.common import reply_text, required_id, required_text
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.supervisor import SupervisorDispatchRequest
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramMessageDTO:
+    """Boundary fields required from one Telegram update/message."""
+
+    update_id: str
+    message_id: str
+    chat_id: str
+    author_id: str
+    text: str
+
+
+class TelegramAdapter:
+    """Pure Telegram-to-domain normalizer."""
+
+    @staticmethod
+    def normalize(message: TelegramMessageDTO) -> NormalizedInboundEvent:
+        update_id = required_id(message.update_id, field="update_id")
+        message_id = required_id(message.message_id, field="message_id")
+        chat_id = required_id(message.chat_id, field="chat_id")
+        target = f"{chat_id}:{message_id}"
+        return NormalizedInboundEvent(
+            platform=Platform.TELEGRAM,
+            external_event_key=target,
+            external_event_id=update_id,
+            external_comment_id=target,
+            external_post_id=chat_id,
+            author_id=required_id(message.author_id, field="author_id"),
+            text=required_text(message.text),
+        )
+
+
+class TelegramReplyClient(Protocol):
+    """Injected client boundary for replies to an opaque Telegram message target."""
+
+    async def reply_to_message(self, target_id: str, text: str) -> str:
+        """Return the created Telegram message identifier."""
+        ...
+
+
+class TelegramReplyPublisher:
+    """Telegram reply adapter backed only by an injected client."""
+
+    def __init__(self, client: TelegramReplyClient) -> None:
+        self.client = client
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        target = required_id(external_comment_id, field="external_comment_id")
+        result = await self.client.reply_to_message(target, reply_text(text))
+        return required_id(result, field="external_result_id")
+
+
+class TelegramSupervisorClient(Protocol):
+    """Injected Telegram client for human-review dispatch only."""
+
+    async def send_supervisor_message(self, text: str) -> str:
+        """Return the Telegram thread/message identifier used for the escalation."""
+        ...
+
+
+class TelegramSupervisorTransport:
+    """Supervisor transport adapter with deterministic plain-text formatting."""
+
+    name = "telegram"
+
+    def __init__(self, client: TelegramSupervisorClient) -> None:
+        self.client = client
+
+    async def dispatch(self, request: SupervisorDispatchRequest) -> str:
+        message = self._format(request)
+        result = await self.client.send_supervisor_message(message)
+        return required_id(result, field="external_thread_id")
+
+    @staticmethod
+    def _format(request: SupervisorDispatchRequest) -> str:
+        text = request.text if request.text is not None else "[no text]"
+        return (
+            "[GHERAS SUPERVISOR]\n"
+            f"escalation_id={required_id(request.escalation_id, field='escalation_id')}\n"
+            f"event_id={required_id(request.event_id, field='event_id')}\n"
+            f"platform={required_id(request.platform, field='platform')}\n"
+            f"correlation_id={required_id(request.correlation_id, field='correlation_id')}\n"
+            f"text={text}"
+        )

--- a/app/adapters/platforms/youtube.py
+++ b/app/adapters/platforms/youtube.py
@@ -1,0 +1,61 @@
+"""YouTube normalization and injectable reply boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.adapters.platforms.common import optional_id, reply_text, required_id, required_text
+from app.domain.events import NormalizedInboundEvent, Platform
+
+
+@dataclass(frozen=True, slots=True)
+class YouTubeCommentDTO:
+    """Boundary fields required from one YouTube comment/comment-thread item."""
+
+    comment_id: str
+    video_id: str
+    author_channel_id: str
+    text: str
+    thread_id: str | None = None
+
+
+class YouTubeAdapter:
+    """Pure YouTube-to-domain normalizer."""
+
+    @staticmethod
+    def normalize(comment: YouTubeCommentDTO) -> NormalizedInboundEvent:
+        comment_id = required_id(comment.comment_id, field="comment_id")
+        thread_id = optional_id(comment.thread_id, field="thread_id")
+        return NormalizedInboundEvent(
+            platform=Platform.YOUTUBE,
+            external_event_key=comment_id,
+            external_event_id=thread_id or comment_id,
+            external_comment_id=comment_id,
+            external_post_id=required_id(comment.video_id, field="video_id"),
+            author_id=required_id(
+                comment.author_channel_id,
+                field="author_channel_id",
+            ),
+            text=required_text(comment.text),
+        )
+
+
+class YouTubeReplyClient(Protocol):
+    """Injected client boundary; production implementation belongs to live integration."""
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        """Return the created YouTube reply identifier."""
+        ...
+
+
+class YouTubeReplyPublisher:
+    """YouTube reply adapter backed only by an injected client."""
+
+    def __init__(self, client: YouTubeReplyClient) -> None:
+        self.client = client
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        target = required_id(external_comment_id, field="external_comment_id")
+        result = await self.client.reply_to_comment(target, reply_text(text))
+        return required_id(result, field="external_result_id")

--- a/prompts/06_PHASE6_PLATFORM_ADAPTERS.md
+++ b/prompts/06_PHASE6_PLATFORM_ADAPTERS.md
@@ -1,0 +1,46 @@
+# Phase 6 — Mock-First Platform Adapters
+
+## Objective
+
+Create provider-specific adapter modules for Facebook, Instagram, Telegram, and YouTube without using real credentials or network endpoints.
+
+## Boundary rule
+
+This phase implements typed provider DTO normalization and injectable outbound client protocols. It does not implement live webhook authentication, polling, OAuth, token refresh, or production HTTP clients.
+
+## Inbound requirements
+
+Each platform adapter must:
+
+- validate required stable identifiers;
+- normalize into the shared `NormalizedInboundEvent`;
+- choose a deterministic event key that collapses redelivery of the same logical comment/message;
+- preserve Arabic/Unicode text without semantic rewriting;
+- never invent missing IDs or content;
+- raise a normalized `AdapterPayloadError` for malformed inputs.
+
+## Outbound requirements
+
+Provider-specific reply publishers may delegate only to an injected client protocol. Production network clients are forbidden in this phase. The common router treats `external_comment_id` as an opaque platform-owned reply target.
+
+Telegram additionally implements the `SupervisorTransportAdapter` boundary using an injected client protocol and a deterministic minimal human-review message.
+
+## Safety
+
+- no tokens, secrets, OAuth, webhooks, polling, or production URLs;
+- no raw provider payload persistence;
+- no domain-layer vendor imports;
+- no user-facing reply generation;
+- no fatwa generation;
+- malformed provider data fails closed.
+
+## Tests
+
+Cover all four platforms, Arabic/Unicode preservation, malformed IDs, duplicate normalization/ingestion, reply delegation with fake clients, Telegram supervisor dispatch with a fake client, and absence of real network libraries from provider modules.
+
+## Gates
+
+- `ruff check app tests`
+- `mypy app`
+- `pytest`
+- independent review before promotion

--- a/tests/test_platform_adapters.py
+++ b/tests/test_platform_adapters.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+from app.adapters.platforms.common import AdapterPayloadError
+from app.adapters.platforms.facebook import (
+    FacebookAdapter,
+    FacebookCommentDTO,
+    FacebookReplyPublisher,
+)
+from app.adapters.platforms.instagram import (
+    InstagramAdapter,
+    InstagramCommentDTO,
+    InstagramReplyPublisher,
+)
+from app.adapters.platforms.telegram import (
+    TelegramAdapter,
+    TelegramMessageDTO,
+    TelegramReplyPublisher,
+    TelegramSupervisorTransport,
+)
+from app.adapters.platforms.youtube import (
+    YouTubeAdapter,
+    YouTubeCommentDTO,
+    YouTubeReplyPublisher,
+)
+from app.domain.events import Platform
+from app.domain.supervisor import SupervisorDispatchRequest
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.ingestion import IngestionService
+
+
+class FakeCommentClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        self.calls.append((comment_id, text))
+        return f"reply-{comment_id}"
+
+
+class FakeTelegramReplyClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def reply_to_message(self, target_id: str, text: str) -> str:
+        self.calls.append((target_id, text))
+        return "telegram-reply-1"
+
+
+class FakeSupervisorClient:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send_supervisor_message(self, text: str) -> str:
+        self.messages.append(text)
+        return "telegram-thread-1"
+
+
+def test_facebook_normalization_preserves_arabic_text() -> None:
+    text = "السلام عليكم، متى يبدأ التسجيل؟"
+    event = FacebookAdapter.normalize(
+        FacebookCommentDTO(
+            comment_id="fb-comment-1",
+            post_id="fb-post-1",
+            author_id="fb-user-1",
+            text=text,
+            event_id="fb-delivery-9",
+        )
+    )
+
+    assert event.platform is Platform.FACEBOOK
+    assert event.external_event_key == "fb-comment-1"
+    assert event.external_event_id == "fb-delivery-9"
+    assert event.external_comment_id == "fb-comment-1"
+    assert event.external_post_id == "fb-post-1"
+    assert event.text == text
+
+
+def test_instagram_normalization_uses_comment_as_stable_event_key() -> None:
+    event = InstagramAdapter.normalize(
+        InstagramCommentDTO(
+            comment_id="ig-comment-1",
+            media_id="ig-media-1",
+            author_id="ig-user-1",
+            text="تعليق إنستغرام",
+            event_id="ig-delivery-1",
+        )
+    )
+
+    assert event.platform is Platform.INSTAGRAM
+    assert event.external_event_key == "ig-comment-1"
+    assert event.external_post_id == "ig-media-1"
+
+
+def test_telegram_redelivery_collapses_on_chat_and_message_identity() -> None:
+    first = TelegramAdapter.normalize(
+        TelegramMessageDTO(
+            update_id="100",
+            message_id="55",
+            chat_id="777",
+            author_id="42",
+            text="مرحبا",
+        )
+    )
+    redelivery = TelegramAdapter.normalize(
+        TelegramMessageDTO(
+            update_id="101",
+            message_id="55",
+            chat_id="777",
+            author_id="42",
+            text="مرحبا",
+        )
+    )
+
+    assert first.external_event_key == "777:55"
+    assert redelivery.external_event_key == first.external_event_key
+    assert first.external_event_id == "100"
+    assert redelivery.external_event_id == "101"
+
+
+def test_youtube_normalization_preserves_video_and_thread_identity() -> None:
+    event = YouTubeAdapter.normalize(
+        YouTubeCommentDTO(
+            comment_id="yt-comment-1",
+            video_id="yt-video-1",
+            author_channel_id="yt-channel-1",
+            text="تعليق يوتيوب",
+            thread_id="yt-thread-1",
+        )
+    )
+
+    assert event.platform is Platform.YOUTUBE
+    assert event.external_event_key == "yt-comment-1"
+    assert event.external_event_id == "yt-thread-1"
+    assert event.external_post_id == "yt-video-1"
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "dto"),
+    [
+        (
+            FacebookAdapter.normalize,
+            FacebookCommentDTO(" ", "post", "author", "text"),
+        ),
+        (
+            InstagramAdapter.normalize,
+            InstagramCommentDTO("comment", " ", "author", "text"),
+        ),
+        (
+            TelegramAdapter.normalize,
+            TelegramMessageDTO("1", " ", "chat", "author", "text"),
+        ),
+        (
+            YouTubeAdapter.normalize,
+            YouTubeCommentDTO("comment", "video", " ", "text"),
+        ),
+    ],
+)
+def test_malformed_required_identifiers_fail_closed(normalizer: object, dto: object) -> None:
+    with pytest.raises(AdapterPayloadError):
+        normalizer(dto)  # type: ignore[operator]
+
+
+def test_empty_provider_text_fails_closed() -> None:
+    with pytest.raises(AdapterPayloadError, match="text"):
+        FacebookAdapter.normalize(
+            FacebookCommentDTO("comment", "post", "author", "   ")
+        )
+
+
+def test_normalized_duplicate_is_idempotent_in_durable_core(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    ingestion = IngestionService(DurableRepository(database))
+
+    first = FacebookAdapter.normalize(
+        FacebookCommentDTO(
+            "same-comment",
+            "post-1",
+            "author-1",
+            "نفس التعليق",
+            event_id="delivery-1",
+        )
+    )
+    duplicate = FacebookAdapter.normalize(
+        FacebookCommentDTO(
+            "same-comment",
+            "post-1",
+            "author-1",
+            "نفس التعليق",
+            event_id="delivery-2",
+        )
+    )
+
+    stored_first = ingestion.ingest_event(first)
+    stored_duplicate = ingestion.ingest_event(duplicate)
+
+    assert stored_first.created is True
+    assert stored_duplicate.created is False
+    assert stored_first.event.id == stored_duplicate.event.id
+
+
+def test_facebook_and_instagram_publishers_delegate_only_to_injected_clients() -> None:
+    facebook_client = FakeCommentClient()
+    instagram_client = FakeCommentClient()
+
+    facebook_id = asyncio.run(
+        FacebookReplyPublisher(facebook_client).publish_reply(
+            external_comment_id="fb-1",
+            text="رد فيسبوك",
+        )
+    )
+    instagram_id = asyncio.run(
+        InstagramReplyPublisher(instagram_client).publish_reply(
+            external_comment_id="ig-1",
+            text="رد إنستغرام",
+        )
+    )
+
+    assert facebook_id == "reply-fb-1"
+    assert instagram_id == "reply-ig-1"
+    assert facebook_client.calls == [("fb-1", "رد فيسبوك")]
+    assert instagram_client.calls == [("ig-1", "رد إنستغرام")]
+
+
+def test_telegram_reply_publisher_delegates_to_injected_client() -> None:
+    client = FakeTelegramReplyClient()
+
+    result = asyncio.run(
+        TelegramReplyPublisher(client).publish_reply(
+            external_comment_id="777:55",
+            text="رد تيليجرام",
+        )
+    )
+
+    assert result == "telegram-reply-1"
+    assert client.calls == [("777:55", "رد تيليجرام")]
+
+
+def test_youtube_reply_publisher_delegates_to_injected_client() -> None:
+    client = FakeCommentClient()
+
+    result = asyncio.run(
+        YouTubeReplyPublisher(client).publish_reply(
+            external_comment_id="yt-comment-1",
+            text="رد يوتيوب",
+        )
+    )
+
+    assert result == "reply-yt-comment-1"
+    assert client.calls == [("yt-comment-1", "رد يوتيوب")]
+
+
+def test_telegram_supervisor_transport_uses_minimal_plain_text_payload() -> None:
+    client = FakeSupervisorClient()
+    request = SupervisorDispatchRequest(
+        escalation_id="esc-1",
+        event_id="event-1",
+        platform="youtube",
+        text="أحتاج مراجعة بشرية",
+        correlation_id="corr-1",
+    )
+
+    result = asyncio.run(TelegramSupervisorTransport(client).dispatch(request))
+
+    assert result == "telegram-thread-1"
+    assert len(client.messages) == 1
+    message = client.messages[0]
+    assert "escalation_id=esc-1" in message
+    assert "event_id=event-1" in message
+    assert "platform=youtube" in message
+    assert "text=أحتاج مراجعة بشرية" in message
+
+
+def test_provider_modules_do_not_embed_network_clients() -> None:
+    modules = [
+        FacebookAdapter,
+        InstagramAdapter,
+        TelegramAdapter,
+        YouTubeAdapter,
+    ]
+    forbidden = ("httpx", "requests", "aiohttp", "graph.facebook.com", "googleapis.com")
+
+    for adapter in modules:
+        source = inspect.getsource(inspect.getmodule(adapter))
+        assert not any(value in source for value in forbidden)


### PR DESCRIPTION
## Summary

Implements Issue #15 as a stacked Phase 6 change above the Supervisor workflow.

### Added
- provider-specific pure normalizers for Facebook, Instagram, Telegram, and YouTube
- deterministic stable inbound event keys
- Arabic/Unicode preservation without semantic rewriting
- fail-closed provider identifier/text validation
- injected reply-client protocols and mock-first reply publishers
- Telegram supervisor transport adapter backed only by an injected client
- no vendor/network client implementation
- duplicate normalized event integration with durable idempotency
- tests covering all four platforms, malformed identifiers, publishing delegation, and absence of embedded network clients

### Safety
- no real credentials, OAuth, tokens, webhooks, polling, or production endpoints
- no raw provider payload persistence
- no domain-layer vendor imports
- no generated replies or fatwas
- live payload parsing/network clients remain gated for Live Integration

### Validation
GitHub Actions run `34452357264` on head `13b46db8e865d22ff788493c543ad3812a4ee2f9`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/05-supervisor`, not `main`. Prior phase reviews/promotions remain prerequisites, and this phase requires its own independent review before promotion.