### PR TITLE
Phase 7 — Fatwa Bridge Contract & Durable Routing

### DIFF
--- a/app/adapters/contracts.py
+++ b/app/adapters/contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from app.domain.classification import ClassificationAssessment, ClassificationRequest
+from app.domain.fatwa import FatwaBridgeDispatch
 from app.domain.moderation import ModerationAssessment, ModerationRequest
 from app.domain.supervisor import SupervisorDispatchRequest
 
@@ -71,4 +72,17 @@ class SupervisorTransportAdapter(Protocol):
 
     async def dispatch(self, request: SupervisorDispatchRequest) -> str:
         """Dispatch an escalation and return an external conversation/thread id."""
+        ...
+
+
+class FatwaBridgeAdapter(Protocol):
+    """Boundary for sending a question to the external supervised fatwa system."""
+
+    @property
+    def name(self) -> str:
+        """Stable bridge identifier suitable for audit metadata."""
+        ...
+
+    async def dispatch(self, request: FatwaBridgeDispatch) -> str:
+        """Dispatch a question and return a stable external case identifier."""
         ...

--- a/app/domain/fatwa.py
+++ b/app/domain/fatwa.py
@@ -1,0 +1,74 @@
+"""Domain models for the isolated supervised fatwa-system bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class FatwaBridgeStatus(StrEnum):
+    """Lifecycle for one durable FATWA bridge request."""
+
+    PENDING_DISPATCH = "pending_dispatch"
+    AWAITING_RESULT = "awaiting_result"
+    APPROVED_RESULT = "approved_result"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+
+
+class FatwaResultOutcome(StrEnum):
+    """Normalized supervised-system result outcome."""
+
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class FatwaBridgeRequest:
+    """One durable request linked to an authoritative FATWA classification."""
+
+    id: str
+    event_id: str
+    classification_result_id: str
+    status: FatwaBridgeStatus
+    dispatch_attempt_count: int
+    bridge_name: str | None
+    external_case_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FatwaBridgeDispatch:
+    """Minimal provider-neutral dispatch payload for the supervised fatwa system."""
+
+    request_id: str
+    event_id: str
+    platform: str
+    question_text: str | None
+    correlation_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class FatwaBridgeResult:
+    """One accepted normalized result from the external supervised fatwa system."""
+
+    id: str
+    request_id: str
+    external_result_key: str
+    outcome: FatwaResultOutcome
+    answer_text: str | None
+    approved_by: str | None
+    source_ref: str
+    received_at: datetime
+
+    @property
+    def publishable_answer(self) -> str | None:
+        """Return text only for an externally approved, fully attributed result."""
+
+        if self.outcome is not FatwaResultOutcome.APPROVED:
+            return None
+        if self.answer_text is None or self.approved_by is None:
+            raise RuntimeError("approved fatwa result is missing approval evidence")
+        return self.answer_text

--- a/app/persistence/fatwa_repository.py
+++ b/app/persistence/fatwa_repository.py
@@ -1,0 +1,499 @@
+"""SQLite persistence for the isolated supervised fatwa-system bridge."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.fatwa import (
+    FatwaBridgeRequest,
+    FatwaBridgeResult,
+    FatwaBridgeStatus,
+    FatwaResultOutcome,
+)
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+_MAX_BRIDGE_NAME = 80
+_MAX_EXTERNAL_ID = 256
+_MAX_APPROVER = 128
+_MAX_SOURCE_REF = 512
+_MAX_ANSWER_TEXT = 16000
+
+
+class FatwaBridgeConflict(RuntimeError):
+    """Raised when request/dispatch idempotency evidence conflicts."""
+
+
+class FatwaResultConflict(RuntimeError):
+    """Raised when an external result key/request is reused with different semantics."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be timezone-aware")
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _bounded(value: str, *, field: str, maximum: int) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if len(normalized) > maximum:
+        raise ValueError(f"{field} must be at most {maximum} characters")
+    return normalized
+
+
+def _compact(value: str, *, field: str, maximum: int) -> str:
+    normalized = _bounded(value, field=field, maximum=maximum)
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field} must be a compact identifier")
+    return normalized
+
+
+def _request_from_row(row: sqlite3.Row) -> FatwaBridgeRequest:
+    return FatwaBridgeRequest(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        classification_result_id=str(row["classification_result_id"]),
+        status=FatwaBridgeStatus(str(row["status"])),
+        dispatch_attempt_count=int(row["dispatch_attempt_count"]),
+        bridge_name=str(row["bridge_name"]) if row["bridge_name"] is not None else None,
+        external_case_id=(
+            str(row["external_case_id"])
+            if row["external_case_id"] is not None
+            else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+        updated_at=_from_timestamp(str(row["updated_at"])),
+    )
+
+
+def _result_from_row(row: sqlite3.Row) -> FatwaBridgeResult:
+    return FatwaBridgeResult(
+        id=str(row["id"]),
+        request_id=str(row["request_id"]),
+        external_result_key=str(row["external_result_key"]),
+        outcome=FatwaResultOutcome(str(row["outcome"])),
+        answer_text=str(row["answer_text"]) if row["answer_text"] is not None else None,
+        approved_by=str(row["approved_by"]) if row["approved_by"] is not None else None,
+        source_ref=str(row["source_ref"]),
+        received_at=_from_timestamp(str(row["received_at"])),
+    )
+
+
+class FatwaRepository:
+    """Durable idempotency and lifecycle boundary for supervised fatwa routing."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def get_for_event(self, event_id: str) -> FatwaBridgeRequest | None:
+        """Return the durable bridge request for an event, if present."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _request_from_row(row) if row is not None else None
+
+    def get_request(self, request_id: str) -> FatwaBridgeRequest:
+        """Load one bridge request by internal id."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+        if row is None:
+            raise LookupError(request_id)
+        return _request_from_row(row)
+
+    def count_requests(self) -> int:
+        """Return bridge request count."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) AS count FROM fatwa_bridge_requests"
+            ).fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def create_request(
+        self,
+        *,
+        event_id: str,
+        classification_result_id: str,
+    ) -> FatwaBridgeRequest:
+        """Create exactly one bridge request for an authoritative FATWA result."""
+
+        request_id = str(uuid4())
+        now = _utc_now()
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event_exists = connection.execute(
+                "SELECT 1 FROM inbound_events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if event_exists is None:
+                connection.rollback()
+                raise EventNotFound(event_id)
+
+            classification = connection.execute(
+                "SELECT event_id, route FROM classification_results WHERE id = ?",
+                (classification_result_id,),
+            ).fetchone()
+            if (
+                classification is None
+                or str(classification["event_id"]) != event_id
+                or str(classification["route"]) != "FATWA"
+            ):
+                connection.rollback()
+                raise ValueError("classification is not eligible for FATWA bridge")
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO fatwa_bridge_requests (
+                        id, event_id, classification_result_id, status,
+                        dispatch_attempt_count, bridge_name, external_case_id,
+                        created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        request_id,
+                        event_id,
+                        classification_result_id,
+                        FatwaBridgeStatus.PENDING_DISPATCH.value,
+                        0,
+                        None,
+                        None,
+                        _to_timestamp(now),
+                        _to_timestamp(now),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                    (request_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted fatwa bridge request could not be reloaded")
+                return _request_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM fatwa_bridge_requests WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _request_from_row(row)
+                if existing.classification_result_id != classification_result_id:
+                    raise FatwaBridgeConflict(
+                        "event is already bound to different FATWA classification evidence"
+                    ) from None
+                return existing
+
+    def record_dispatch_failure(self, request_id: str) -> FatwaBridgeRequest:
+        """Increment an attempt counter without persisting raw transport errors."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(request_id)
+            request = _request_from_row(row)
+            if request.status is not FatwaBridgeStatus.PENDING_DISPATCH:
+                connection.rollback()
+                raise ValueError("only pending FATWA requests may record dispatch failure")
+            now = _utc_now()
+            connection.execute(
+                """
+                UPDATE fatwa_bridge_requests
+                SET dispatch_attempt_count = dispatch_attempt_count + 1,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (_to_timestamp(now), request_id),
+            )
+            updated = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("fatwa dispatch failure state could not be reloaded")
+        return _request_from_row(updated)
+
+    def mark_dispatched(
+        self,
+        request_id: str,
+        *,
+        bridge_name: str,
+        external_case_id: str,
+    ) -> FatwaBridgeRequest:
+        """Record successful dispatch and transition to awaiting_result."""
+
+        bridge = _compact(bridge_name, field="bridge_name", maximum=_MAX_BRIDGE_NAME)
+        case_id = _compact(
+            external_case_id,
+            field="external_case_id",
+            maximum=_MAX_EXTERNAL_ID,
+        )
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(request_id)
+            current = _request_from_row(row)
+            if current.status in {
+                FatwaBridgeStatus.AWAITING_RESULT,
+                FatwaBridgeStatus.APPROVED_RESULT,
+                FatwaBridgeStatus.REJECTED,
+            }:
+                connection.commit()
+                if current.bridge_name == bridge and current.external_case_id == case_id:
+                    return current
+                raise FatwaBridgeConflict(
+                    "fatwa request is already bound to different dispatch evidence"
+                )
+            if current.status is FatwaBridgeStatus.CANCELLED:
+                connection.rollback()
+                raise ValueError("cancelled FATWA request cannot be dispatched")
+
+            now = _utc_now()
+            try:
+                connection.execute(
+                    """
+                    UPDATE fatwa_bridge_requests
+                    SET status = ?, dispatch_attempt_count = dispatch_attempt_count + 1,
+                        bridge_name = ?, external_case_id = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        FatwaBridgeStatus.AWAITING_RESULT.value,
+                        bridge,
+                        case_id,
+                        _to_timestamp(now),
+                        request_id,
+                    ),
+                )
+                updated = connection.execute(
+                    "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                    (request_id,),
+                ).fetchone()
+                connection.commit()
+            except sqlite3.IntegrityError as exc:
+                connection.rollback()
+                raise FatwaBridgeConflict(
+                    "external_case_id is already bound to another FATWA request"
+                ) from exc
+        if updated is None:
+            raise RuntimeError("dispatched fatwa request could not be reloaded")
+        return _request_from_row(updated)
+
+    def cancel(self, request_id: str) -> FatwaBridgeRequest:
+        """Cancel a request only before a terminal external result exists."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(request_id)
+            current = _request_from_row(row)
+            if current.status in {
+                FatwaBridgeStatus.APPROVED_RESULT,
+                FatwaBridgeStatus.REJECTED,
+                FatwaBridgeStatus.CANCELLED,
+            }:
+                connection.rollback()
+                raise ValueError("terminal FATWA request cannot be cancelled")
+            now = _utc_now()
+            connection.execute(
+                "UPDATE fatwa_bridge_requests SET status = ?, updated_at = ? WHERE id = ?",
+                (FatwaBridgeStatus.CANCELLED.value, _to_timestamp(now), request_id),
+            )
+            updated = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("cancelled fatwa request could not be reloaded")
+        return _request_from_row(updated)
+
+    def get_result(self, request_id: str) -> FatwaBridgeResult | None:
+        """Return the accepted external result for a request, if present."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM fatwa_bridge_results WHERE request_id = ?",
+                (request_id,),
+            ).fetchone()
+        return _result_from_row(row) if row is not None else None
+
+    def accept_result(
+        self,
+        request_id: str,
+        *,
+        external_result_key: str,
+        outcome: FatwaResultOutcome,
+        answer_text: str | None,
+        approved_by: str | None,
+        source_ref: str,
+        received_at: datetime,
+    ) -> FatwaBridgeResult:
+        """Accept one attributed external result and atomically close the request."""
+
+        result_key = _compact(
+            external_result_key,
+            field="external_result_key",
+            maximum=_MAX_EXTERNAL_ID,
+        )
+        source = _bounded(source_ref, field="source_ref", maximum=_MAX_SOURCE_REF)
+        received_timestamp = _to_timestamp(received_at)
+
+        if outcome is FatwaResultOutcome.APPROVED:
+            if answer_text is None or approved_by is None:
+                raise ValueError("approved FATWA result requires answer_text and approved_by")
+            answer = _bounded(
+                answer_text,
+                field="answer_text",
+                maximum=_MAX_ANSWER_TEXT,
+            )
+            approver = _bounded(
+                approved_by,
+                field="approved_by",
+                maximum=_MAX_APPROVER,
+            )
+        else:
+            if answer_text is not None or approved_by is not None:
+                raise ValueError("rejected FATWA result must not contain answer or approver")
+            answer = None
+            approver = None
+
+        result_id = str(uuid4())
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            request_row = connection.execute(
+                "SELECT * FROM fatwa_bridge_requests WHERE id = ?",
+                (request_id,),
+            ).fetchone()
+            if request_row is None:
+                connection.rollback()
+                raise LookupError(request_id)
+
+            existing_row = connection.execute(
+                """
+                SELECT * FROM fatwa_bridge_results
+                WHERE request_id = ? OR external_result_key = ?
+                LIMIT 1
+                """,
+                (request_id, result_key),
+            ).fetchone()
+            if existing_row is not None:
+                connection.commit()
+                existing = _result_from_row(existing_row)
+                if (
+                    existing.request_id == request_id
+                    and existing.external_result_key == result_key
+                    and existing.outcome is outcome
+                    and existing.answer_text == answer
+                    and existing.approved_by == approver
+                    and existing.source_ref == source
+                ):
+                    return existing
+                raise FatwaResultConflict(
+                    "FATWA result key or request is already bound differently"
+                )
+
+            request = _request_from_row(request_row)
+            if request.status is not FatwaBridgeStatus.AWAITING_RESULT:
+                connection.rollback()
+                raise ValueError("FATWA result requires awaiting_result state")
+
+            terminal_status = (
+                FatwaBridgeStatus.APPROVED_RESULT
+                if outcome is FatwaResultOutcome.APPROVED
+                else FatwaBridgeStatus.REJECTED
+            )
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO fatwa_bridge_results (
+                        id, request_id, external_result_key, outcome,
+                        answer_text, approved_by, source_ref, received_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        result_id,
+                        request_id,
+                        result_key,
+                        outcome.value,
+                        answer,
+                        approver,
+                        source,
+                        received_timestamp,
+                    ),
+                )
+                now = _utc_now()
+                connection.execute(
+                    "UPDATE fatwa_bridge_requests SET status = ?, updated_at = ? WHERE id = ?",
+                    (terminal_status.value, _to_timestamp(now), request_id),
+                )
+                created = connection.execute(
+                    "SELECT * FROM fatwa_bridge_results WHERE id = ?",
+                    (result_id,),
+                ).fetchone()
+                connection.commit()
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    """
+                    SELECT * FROM fatwa_bridge_results
+                    WHERE request_id = ? OR external_result_key = ?
+                    LIMIT 1
+                    """,
+                    (request_id, result_key),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _result_from_row(row)
+                if (
+                    existing.request_id == request_id
+                    and existing.external_result_key == result_key
+                    and existing.outcome is outcome
+                    and existing.answer_text == answer
+                    and existing.approved_by == approver
+                    and existing.source_ref == source
+                ):
+                    return existing
+                raise FatwaResultConflict(
+                    "concurrent FATWA result conflicts with accepted result"
+                ) from None
+
+        if created is None:
+            raise RuntimeError("accepted fatwa result could not be reloaded")
+        return _result_from_row(created)

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -234,4 +234,67 @@ CREATE TABLE IF NOT EXISTS supervisor_responses (
 
 CREATE INDEX IF NOT EXISTS idx_supervisor_responses_received
 ON supervisor_responses (received_at);
+
+CREATE TABLE IF NOT EXISTS fatwa_bridge_requests (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    classification_result_id TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (
+        status IN (
+            'pending_dispatch',
+            'awaiting_result',
+            'approved_result',
+            'rejected',
+            'cancelled'
+        )
+    ),
+    dispatch_attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (
+        dispatch_attempt_count >= 0
+    ),
+    bridge_name TEXT,
+    external_case_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
+    FOREIGN KEY (classification_result_id)
+        REFERENCES classification_results(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fatwa_bridge_external_case
+ON fatwa_bridge_requests (external_case_id)
+WHERE external_case_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_fatwa_bridge_requests_status
+ON fatwa_bridge_requests (status, created_at);
+
+CREATE TABLE IF NOT EXISTS fatwa_bridge_results (
+    id TEXT PRIMARY KEY,
+    request_id TEXT NOT NULL UNIQUE,
+    external_result_key TEXT NOT NULL UNIQUE,
+    outcome TEXT NOT NULL CHECK (outcome IN ('approved', 'rejected')),
+    answer_text TEXT,
+    approved_by TEXT,
+    source_ref TEXT NOT NULL CHECK (length(trim(source_ref)) > 0),
+    received_at TEXT NOT NULL,
+    FOREIGN KEY (request_id)
+        REFERENCES fatwa_bridge_requests(id) ON DELETE CASCADE,
+    CHECK (
+        (
+            outcome = 'approved'
+            AND answer_text IS NOT NULL
+            AND length(trim(answer_text)) > 0
+            AND approved_by IS NOT NULL
+            AND length(trim(approved_by)) > 0
+        )
+        OR
+        (
+            outcome = 'rejected'
+            AND answer_text IS NULL
+            AND approved_by IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_fatwa_bridge_results_received
+ON fatwa_bridge_results (received_at);
 """

--- a/app/services/fatwa.py
+++ b/app/services/fatwa.py
@@ -1,0 +1,128 @@
+"""Durable FATWA bridge orchestration with no religious answer generation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.domain.classification import ClassificationRoute
+from app.domain.fatwa import (
+    FatwaBridgeDispatch,
+    FatwaBridgeRequest,
+    FatwaBridgeResult,
+    FatwaBridgeStatus,
+    FatwaResultOutcome,
+)
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.repositories import DurableRepository
+
+
+class FatwaNotEligible(RuntimeError):
+    """Raised when an event has no authoritative FATWA classification."""
+
+
+class FatwaDispatchNotReady(RuntimeError):
+    """Raised when dispatch preparation is requested from a non-pending request."""
+
+
+class FatwaService:
+    """Route FATWA events to an external supervised system without generating answers."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        classifications: ClassificationRepository,
+        fatwas: FatwaRepository,
+    ) -> None:
+        self.events = events
+        self.classifications = classifications
+        self.fatwas = fatwas
+
+    def ensure_request(self, event_id: str) -> FatwaBridgeRequest:
+        """Create or return the one request justified by a durable FATWA route."""
+
+        existing = self.fatwas.get_for_event(event_id)
+        if existing is not None:
+            return existing
+        classification = self.classifications.get_for_event(event_id)
+        if classification is None or classification.route is not ClassificationRoute.FATWA:
+            raise FatwaNotEligible("fatwa bridge requires a durable FATWA classification")
+        return self.fatwas.create_request(
+            event_id=event_id,
+            classification_result_id=classification.id,
+        )
+
+    def prepare_dispatch(self, event_id: str) -> FatwaBridgeDispatch:
+        """Return the minimal external bridge payload without performing a live call."""
+
+        request = self.ensure_request(event_id)
+        if request.status is not FatwaBridgeStatus.PENDING_DISPATCH:
+            raise FatwaDispatchNotReady(
+                "only pending_dispatch FATWA request may produce dispatch payload"
+            )
+        event = self.events.get_event(event_id)
+        return FatwaBridgeDispatch(
+            request_id=request.id,
+            event_id=event.id,
+            platform=event.platform.value,
+            question_text=event.text,
+            correlation_id=event.correlation_id,
+        )
+
+    def record_dispatch_failure(self, event_id: str) -> FatwaBridgeRequest:
+        """Record an unsuccessful bridge attempt without raw diagnostics."""
+
+        request = self.ensure_request(event_id)
+        return self.fatwas.record_dispatch_failure(request.id)
+
+    def mark_dispatched(
+        self,
+        event_id: str,
+        *,
+        bridge_name: str,
+        external_case_id: str,
+    ) -> FatwaBridgeRequest:
+        """Record successful handoff to the external supervised fatwa system."""
+
+        request = self.ensure_request(event_id)
+        return self.fatwas.mark_dispatched(
+            request.id,
+            bridge_name=bridge_name,
+            external_case_id=external_case_id,
+        )
+
+    def accept_result(
+        self,
+        event_id: str,
+        *,
+        external_result_key: str,
+        outcome: FatwaResultOutcome,
+        answer_text: str | None,
+        approved_by: str | None,
+        source_ref: str,
+        received_at: datetime,
+    ) -> FatwaBridgeResult:
+        """Accept only normalized external supervised result evidence."""
+
+        request = self.ensure_request(event_id)
+        return self.fatwas.accept_result(
+            request.id,
+            external_result_key=external_result_key,
+            outcome=outcome,
+            answer_text=answer_text,
+            approved_by=approved_by,
+            source_ref=source_ref,
+            received_at=received_at,
+        )
+
+    def get_publishable_answer(self, event_id: str) -> str | None:
+        """Expose exact external answer text only after a fully approved terminal result."""
+
+        request = self.fatwas.get_for_event(event_id)
+        if request is None or request.status is not FatwaBridgeStatus.APPROVED_RESULT:
+            return None
+        result = self.fatwas.get_result(request.id)
+        if result is None:
+            raise RuntimeError("approved FATWA request is missing its external result")
+        return result.publishable_answer

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,9 +29,16 @@ FastAPI owns health endpoints and, in later phases, inbound webhook endpoints. I
 
 ### Platform adapters
 
-Facebook, Instagram, Telegram, and YouTube integrations implement adapter contracts. Domain and routing logic must not call vendor SDKs or raw HTTP endpoints directly.
+Facebook, Instagram, Telegram, and YouTube integrations implement provider-specific adapter modules while domain/services remain provider-neutral.
 
-Each adapter normalizes platform-specific identifiers and payloads into the shared inbound event model. Platform-specific details may be preserved only where needed for correct routing/publishing and must not leak into core state-machine semantics.
+Phase 6 implements only pure normalization plus injected client protocols. It deliberately does not implement production OAuth, webhook verification, polling, token refresh, or network clients. Stable inbound identities are normalized as follows:
+
+- Facebook: comment id.
+- Instagram: comment id.
+- Telegram: `chat_id:message_id`; update id remains delivery metadata.
+- YouTube: comment id; thread id may be retained separately.
+
+Adapters preserve Arabic/Unicode text verbatim and fail closed when required identifiers or text are missing. Reply publishers and the Telegram supervisor transport delegate only to injected client protocols. Raw provider payloads are not persisted.
 
 ### Durable event boundary
 
@@ -48,6 +55,8 @@ The SQLite durable layer contains persistent concerns including:
 - `faq_resolutions`: one exact-key FAQ resolution per classified event.
 - `supervisor_escalations`: one durable human escalation per eligible event.
 - `supervisor_responses`: one accepted human response per escalation.
+- `fatwa_bridge_requests`: one durable supervised-fatwa request per FATWA event.
+- `fatwa_bridge_results`: one normalized attributed external result per bridge request.
 
 Inbound uniqueness is `(platform, external_event_key)`. Outbound uniqueness is `idempotency_key`. Duplicate work must resolve to the existing durable record instead of creating a second semantic action.
 
@@ -109,14 +118,9 @@ Each `faq_resolution` links the event and classification to the exact approved e
 
 ### Human supervisor boundary
 
-Human escalation is eligible only when:
+Human escalation is eligible only when classification is explicitly `SUPERVISOR`, or a `FAQ` classification has a durable `supervisor_required` FAQ resolution.
 
-1. classification is explicitly `SUPERVISOR`; or
-2. a `FAQ` classification has a durable `supervisor_required` FAQ resolution.
-
-FATWA-routed events and successfully resolved FAQ events are not eligible for this workflow.
-
-Telegram is the intended V1 supervisor transport, but transport is not the source of truth. `supervisor_escalations` and `supervisor_responses` persist workflow state independently of Telegram.
+FATWA-routed events and successfully resolved FAQ events are not eligible for this workflow. Telegram is the intended V1 supervisor transport, but transport is not the source of truth; SQLite holds escalation and response state.
 
 The escalation lifecycle is:
 
@@ -126,13 +130,26 @@ pending_dispatch -> awaiting_response -> responded
        └──────────────> cancelled
 ```
 
-The service prepares a minimal normalized dispatch request but does not perform a live Telegram call in Phase 5. Successful external dispatch is recorded only after a transport returns a stable external thread identifier. Failed attempts increment durable attempt metadata without storing raw exception text.
-
-One accepted human response is allowed per escalation. Duplicate identical provider updates are idempotent; reuse of an external response key or escalation with different response semantics fails closed as a conflict. Supervisor responses are human-provided content and are not automatically published by this phase.
+One accepted human response is allowed per escalation. Duplicate identical provider updates are idempotent; conflicting response or transport evidence fails closed.
 
 ### Fatwa bot bridge
 
-The existing fatwa bot remains a separate system boundary. Gheras exchanges only the information required to route a question and consume an approved supervised result. Gheras AI must never fabricate or infer a fatwa.
+A `FATWA` classification is only a routing decision and never contains a religious answer. Gheras cannot generate, rewrite, summarize, infer, complete, or improve a fatwa.
+
+Phase 7 adds a durable bridge boundary to an external supervised fatwa system. Eligibility requires an exact durable classification route of `FATWA`. The request lifecycle is:
+
+```text
+pending_dispatch -> awaiting_result -> approved_result
+                              └──────> rejected
+       │                  │
+       └──────────────────┴────> cancelled
+```
+
+The bridge prepares only minimal normalized question/identity data and performs no live call in this phase. Failed dispatch attempts increment a counter without storing raw provider errors. Successful dispatch records only a stable bridge name and external case id.
+
+A bridge result becomes publishable evidence only when the external result is `approved` and includes all of: non-empty answer text supplied by the supervised system, a non-empty `approved_by` value, a non-empty `source_ref`, and a stable unique external result key. A rejected result is structurally forbidden from carrying answer text or an approver.
+
+`fatwa_bridge_results` preserves the exact approved external text; Gheras does not transform it. Duplicate identical results are idempotent, while reuse of a request/result key with different semantics fails closed. The existing `telegram-fatwa-bot-v2` runtime and repository remain untouched until a separate Live Integration human gate.
 
 ### Publishing dispatcher
 
@@ -142,7 +159,7 @@ Publishing is separated from classification, FAQ resolution, supervisor response
 
 - Persist first, process later.
 - Inbound platform events are idempotent.
-- Moderation, classification, FAQ resolution, and supervisor escalation are durable.
+- Moderation, classification, FAQ resolution, supervisor escalation, and fatwa bridge state are durable.
 - Duplicate/racing workers converge on one semantic durable result.
 - Outbound replies/actions are idempotent.
 - SQLite foreign keys are enabled.
@@ -150,6 +167,7 @@ Publishing is separated from classification, FAQ resolution, supervisor response
 - External failure must not silently lose accepted work.
 - Low-confidence or uncertain routing escalates rather than guesses.
 - Possible religious content fails toward FATWA routing, never an AI-generated answer.
+- Fatwa text is publishable only after explicit external approval/provenance evidence.
 - Secrets come from environment variables and are never committed.
 - Raw external provider payloads are not blindly persisted.
 
@@ -160,4 +178,6 @@ Publishing is separated from classification, FAQ resolution, supervisor response
 - Phase 2: mock-first fail-closed moderation and durable moderation results.
 - Phase 3: mock-first routing-only classification with religious safety override.
 - Phase 4: versioned approved FAQ store and exact-key durable resolution.
-- Phase 5: durable human supervisor escalation/response workflow and transport contract, with no live Telegram calls.
+- Phase 5: durable human supervisor escalation/response workflow; no live Telegram calls.
+- Phase 6: mock-first four-platform normalizers and injected publisher/transport clients; no live network clients.
+- Phase 7: durable supervised fatwa bridge request/result lifecycle; no legacy-bot call or modification.

--- a/prompts/07_PHASE7_FATWA_BRIDGE.md
+++ b/prompts/07_PHASE7_FATWA_BRIDGE.md
@@ -1,0 +1,45 @@
+# Phase 7 — Fatwa Bridge
+
+## Objective
+
+Implement a durable, mock-first bridge boundary for events whose authoritative classification route is `FATWA`.
+
+## Absolute prohibition
+
+Gheras must never generate, rewrite, summarize, infer, complete, or improve a religious ruling. A FATWA classification is routing evidence only and never contains a publishable answer.
+
+## Request lifecycle
+
+- exactly one durable bridge request per FATWA event;
+- `pending_dispatch -> awaiting_result -> approved_result | rejected`;
+- explicit `cancelled` state before a terminal result;
+- failed dispatch attempts increment normalized durable metadata without raw error text.
+
+## Approved result gate
+
+A result is publishable later only when all are true:
+
+- request belongs to a durable FATWA classification;
+- request is in `awaiting_result`;
+- external result says approved;
+- non-empty answer text is supplied by the external supervised fatwa system;
+- `approved_by` is present;
+- `source_ref` is present;
+- external result key is stable and unique.
+
+Rejected/unapproved results must carry no answer text. Duplicate identical results are idempotent. Reuse of a result key or request with different semantics fails closed.
+
+## Live-integration gate
+
+Do not call, modify, stop, or redeploy `telegram-fatwa-bot-v2`. No real secret/token or production network call is allowed in this phase. The adapter contract may be defined, but only fake clients/tests may exercise it.
+
+## Persistence
+
+Store normalized identifiers, lifecycle state, approved external answer/provenance, and timestamps only. Never persist raw bot updates, secret headers, tokens, model prompts, or AI-generated religious text.
+
+## Gates
+
+- `ruff check app tests`
+- `mypy app`
+- `pytest`
+- independent review before promotion

--- a/tests/test_fatwa_bridge.py
+++ b/tests/test_fatwa_bridge.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.fatwa import FatwaBridgeStatus, FatwaResultOutcome
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.fatwa_repository import (
+    FatwaBridgeConflict,
+    FatwaRepository,
+    FatwaResultConflict,
+)
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.fatwa import FatwaDispatchNotReady, FatwaNotEligible, FatwaService
+from app.services.ingestion import IngestionService
+
+
+def _build(
+    tmp_path: Path,
+) -> tuple[
+    SQLiteDatabase,
+    DurableRepository,
+    ClassificationRepository,
+    FatwaRepository,
+    FatwaService,
+]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    events = DurableRepository(database)
+    classifications = ClassificationRepository(database)
+    fatwas = FatwaRepository(database)
+    service = FatwaService(
+        events=events,
+        classifications=classifications,
+        fatwas=fatwas,
+    )
+    return database, events, classifications, fatwas, service
+
+
+def _ingest(
+    events: DurableRepository,
+    *,
+    key: str,
+    platform: Platform = Platform.FACEBOOK,
+    text: str | None = "ما حكم هذا الأمر؟",
+) -> str:
+    return IngestionService(events).ingest_event(
+        NormalizedInboundEvent(
+            platform=platform,
+            external_event_key=key,
+            text=text,
+        )
+    ).event.id
+
+
+def _classify(
+    classifications: ClassificationRepository,
+    event_id: str,
+    route: ClassificationRoute,
+) -> str:
+    if route is ClassificationRoute.FATWA:
+        decision = ClassificationDecision(
+            route=route,
+            reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+        )
+        religious = True
+    elif route is ClassificationRoute.SUPERVISOR:
+        decision = ClassificationDecision(
+            route=route,
+            reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+        )
+        religious = False
+    else:
+        decision = ClassificationDecision(
+            route=route,
+            reasons=(ClassificationReason.CONFIDENT_FAQ,),
+            faq_key="fixture.key",
+        )
+        religious = False
+    return classifications.create_for_event(
+        event_id=event_id,
+        decision=decision,
+        religious_possible=religious,
+        confidence=0.99,
+        adapter_name="test-classifier",
+        adapter_version="1",
+    ).id
+
+
+def _dispatch(service: FatwaService, event_id: str, case_id: str = "case-1") -> None:
+    service.mark_dispatched(
+        event_id,
+        bridge_name="supervised-fatwa-system",
+        external_case_id=case_id,
+    )
+
+
+def test_fatwa_classification_creates_one_pending_request(tmp_path: Path) -> None:
+    _, events, classifications, fatwas, service = _build(tmp_path)
+    event_id = _ingest(events, key="fatwa-1")
+    classification_id = _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    request = service.ensure_request(event_id)
+
+    assert request.classification_result_id == classification_id
+    assert request.status is FatwaBridgeStatus.PENDING_DISPATCH
+    assert request.dispatch_attempt_count == 0
+    assert fatwas.count_requests() == 1
+
+
+@pytest.mark.parametrize(
+    "route",
+    [ClassificationRoute.SUPERVISOR, ClassificationRoute.FAQ],
+)
+def test_non_fatwa_routes_are_not_eligible(tmp_path: Path, route: ClassificationRoute) -> None:
+    _, events, classifications, fatwas, service = _build(tmp_path)
+    event_id = _ingest(events, key=f"not-fatwa-{route.value}")
+    _classify(classifications, event_id, route)
+
+    with pytest.raises(FatwaNotEligible):
+        service.ensure_request(event_id)
+
+    assert fatwas.count_requests() == 0
+
+
+def test_repository_cannot_bypass_fatwa_eligibility(tmp_path: Path) -> None:
+    _, events, classifications, fatwas, _ = _build(tmp_path)
+    event_id = _ingest(events, key="repo-gate")
+    classification_id = _classify(
+        classifications,
+        event_id,
+        ClassificationRoute.SUPERVISOR,
+    )
+
+    with pytest.raises(ValueError, match="not eligible"):
+        fatwas.create_request(
+            event_id=event_id,
+            classification_result_id=classification_id,
+        )
+
+
+def test_prepare_dispatch_is_minimal_and_preserves_question(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    text = "ما حكم المعاملة بهذه الصورة؟"
+    event_id = _ingest(
+        events,
+        key="dispatch-payload",
+        platform=Platform.YOUTUBE,
+        text=text,
+    )
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    dispatch = service.prepare_dispatch(event_id)
+
+    assert dispatch.event_id == event_id
+    assert dispatch.platform == "youtube"
+    assert dispatch.question_text == text
+    assert dispatch.correlation_id
+
+
+def test_dispatch_failure_does_not_advance_state(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-failure")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    request = service.record_dispatch_failure(event_id)
+
+    assert request.status is FatwaBridgeStatus.PENDING_DISPATCH
+    assert request.dispatch_attempt_count == 1
+
+
+def test_dispatch_is_idempotent_and_conflicting_case_fails(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-idempotency")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    first = service.mark_dispatched(
+        event_id,
+        bridge_name="supervised-fatwa-system",
+        external_case_id="case-100",
+    )
+    second = service.mark_dispatched(
+        event_id,
+        bridge_name="supervised-fatwa-system",
+        external_case_id="case-100",
+    )
+
+    assert first.id == second.id
+    assert second.status is FatwaBridgeStatus.AWAITING_RESULT
+    assert second.dispatch_attempt_count == 1
+
+    with pytest.raises(FatwaBridgeConflict):
+        service.mark_dispatched(
+            event_id,
+            bridge_name="supervised-fatwa-system",
+            external_case_id="case-101",
+        )
+
+
+def test_prepare_dispatch_rejected_after_successful_dispatch(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="dispatch-state")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+
+    with pytest.raises(FatwaDispatchNotReady):
+        service.prepare_dispatch(event_id)
+
+
+def test_result_requires_awaiting_state(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="early-result")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    with pytest.raises(ValueError, match="awaiting_result"):
+        service.accept_result(
+            event_id,
+            external_result_key="result-1",
+            outcome=FatwaResultOutcome.REJECTED,
+            answer_text=None,
+            approved_by=None,
+            source_ref="fixture://fatwa/result-1",
+            received_at=datetime(2026, 9, 10, 8, 0, tzinfo=UTC),
+        )
+
+
+def test_approved_result_requires_attribution_and_preserves_exact_text(
+    tmp_path: Path,
+) -> None:
+    _, events, classifications, fatwas, service = _build(tmp_path)
+    event_id = _ingest(events, key="approved-result")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+    answer = "هذا نص الجواب المعتمد كما ورد من الجهة الشرعية."
+
+    result = service.accept_result(
+        event_id,
+        external_result_key="result-approved",
+        outcome=FatwaResultOutcome.APPROVED,
+        answer_text=answer,
+        approved_by="scholar-reviewer-1",
+        source_ref="fixture://fatwa/approved-result",
+        received_at=datetime(2026, 9, 10, 8, 5, tzinfo=UTC),
+    )
+
+    request = fatwas.get_for_event(event_id)
+    assert request is not None
+    assert request.status is FatwaBridgeStatus.APPROVED_RESULT
+    assert result.publishable_answer == answer
+    assert service.get_publishable_answer(event_id) == answer
+
+
+@pytest.mark.parametrize(
+    ("answer_text", "approved_by"),
+    [(None, "reviewer"), ("جواب", None), ("   ", "reviewer")],
+)
+def test_approved_result_missing_evidence_fails_closed(
+    tmp_path: Path,
+    answer_text: str | None,
+    approved_by: str | None,
+) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key=f"bad-approved-{answer_text}-{approved_by}")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+
+    with pytest.raises(ValueError):
+        service.accept_result(
+            event_id,
+            external_result_key="bad-approved",
+            outcome=FatwaResultOutcome.APPROVED,
+            answer_text=answer_text,
+            approved_by=approved_by,
+            source_ref="fixture://fatwa/bad",
+            received_at=datetime(2026, 9, 10, 8, 10, tzinfo=UTC),
+        )
+
+    assert service.get_publishable_answer(event_id) is None
+
+
+def test_rejected_result_carries_no_publishable_answer(tmp_path: Path) -> None:
+    _, events, classifications, fatwas, service = _build(tmp_path)
+    event_id = _ingest(events, key="rejected-result")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+
+    result = service.accept_result(
+        event_id,
+        external_result_key="result-rejected",
+        outcome=FatwaResultOutcome.REJECTED,
+        answer_text=None,
+        approved_by=None,
+        source_ref="fixture://fatwa/rejected-result",
+        received_at=datetime(2026, 9, 10, 8, 15, tzinfo=UTC),
+    )
+
+    request = fatwas.get_for_event(event_id)
+    assert request is not None
+    assert request.status is FatwaBridgeStatus.REJECTED
+    assert result.publishable_answer is None
+    assert service.get_publishable_answer(event_id) is None
+
+
+def test_rejected_result_rejects_answer_text(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="rejected-with-answer")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+
+    with pytest.raises(ValueError, match="must not contain"):
+        service.accept_result(
+            event_id,
+            external_result_key="bad-rejected",
+            outcome=FatwaResultOutcome.REJECTED,
+            answer_text="نص غير مسموح",
+            approved_by=None,
+            source_ref="fixture://fatwa/rejected",
+            received_at=datetime(2026, 9, 10, 8, 20, tzinfo=UTC),
+        )
+
+
+def test_duplicate_identical_result_is_idempotent(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="result-idempotent")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+    kwargs = dict(
+        external_result_key="result-same",
+        outcome=FatwaResultOutcome.APPROVED,
+        answer_text="جواب معتمد",
+        approved_by="reviewer-1",
+        source_ref="fixture://fatwa/same",
+        received_at=datetime(2026, 9, 10, 8, 25, tzinfo=UTC),
+    )
+
+    first = service.accept_result(event_id, **kwargs)
+    second = service.accept_result(event_id, **kwargs)
+
+    assert first.id == second.id
+
+
+def test_conflicting_second_result_fails_closed(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="result-conflict")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+    service.accept_result(
+        event_id,
+        external_result_key="result-first",
+        outcome=FatwaResultOutcome.APPROVED,
+        answer_text="الجواب الأول",
+        approved_by="reviewer-1",
+        source_ref="fixture://fatwa/first",
+        received_at=datetime(2026, 9, 10, 8, 30, tzinfo=UTC),
+    )
+
+    with pytest.raises(FatwaResultConflict):
+        service.accept_result(
+            event_id,
+            external_result_key="result-second",
+            outcome=FatwaResultOutcome.APPROVED,
+            answer_text="جواب مختلف",
+            approved_by="reviewer-2",
+            source_ref="fixture://fatwa/second",
+            received_at=datetime(2026, 9, 10, 8, 31, tzinfo=UTC),
+        )
+
+
+def test_concurrent_duplicate_request_converges(tmp_path: Path) -> None:
+    _, events, classifications, fatwas, service = _build(tmp_path)
+    event_id = _ingest(events, key="request-race")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(lambda _: service.ensure_request(event_id).id, range(20)))
+
+    assert len(set(ids)) == 1
+    assert fatwas.count_requests() == 1
+
+
+def test_concurrent_identical_results_converge(tmp_path: Path) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key="result-race")
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+    _dispatch(service, event_id)
+
+    def accept(_: int) -> str:
+        return service.accept_result(
+            event_id,
+            external_result_key="result-race",
+            outcome=FatwaResultOutcome.APPROVED,
+            answer_text="نص معتمد واحد",
+            approved_by="reviewer-1",
+            source_ref="fixture://fatwa/race",
+            received_at=datetime(2026, 9, 10, 8, 35, tzinfo=UTC),
+        ).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(accept, range(20)))
+
+    assert len(set(ids)) == 1
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_share_fatwa_bridge_semantics(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    _, events, classifications, _, service = _build(tmp_path)
+    event_id = _ingest(events, key=f"fatwa-{platform.value}", platform=platform)
+    _classify(classifications, event_id, ClassificationRoute.FATWA)
+
+    request = service.ensure_request(event_id)
+
+    assert request.status is FatwaBridgeStatus.PENDING_DISPATCH
+
+
+def test_fatwa_tables_do_not_store_raw_provider_or_model_fields(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+
+    with database.connect() as connection:
+        request_columns = connection.execute(
+            "PRAGMA table_info(fatwa_bridge_requests)"
+        ).fetchall()
+        result_columns = connection.execute(
+            "PRAGMA table_info(fatwa_bridge_results)"
+        ).fetchall()
+
+    names = {str(row["name"]).lower() for row in (*request_columns, *result_columns)}
+    forbidden = {"payload", "token", "secret", "authorization", "prompt", "generated"}
+    assert not any(fragment in name for name in names for fragment in forbidden)


### PR DESCRIPTION
## Summary

Implements Issue #18 as a stacked Phase 7 change above Platform Adapters.

### Added
- durable one-per-event FATWA bridge requests
- eligibility enforced against exact durable `FATWA` classification
- lifecycle: pending_dispatch -> awaiting_result -> approved_result/rejected, plus explicit cancellation
- bounded dispatch attempt metadata without raw provider diagnostics
- stable bridge/external case identifiers with conflict detection
- one normalized external result per request
- approved-result gate requiring exact answer text + approved_by + source_ref + stable result key
- rejected results structurally forbidden from carrying answer text or approver
- exact external approved text preserved without generation/rewriting/summarization
- duplicate/concurrent request/result idempotency
- fail-closed conflicting request/result reuse

### Safety
- no real token/secret
- no live fatwa-bot/network call
- no modification or shutdown of `telegram-fatwa-bot-v2`
- no AI-generated religious text
- no publishable answer before explicit external approval/provenance
- no raw bot/provider payload persistence

### Validation
GitHub Actions run `34453058502` on head `ae45dddb954c8058485f5ab441989cb0fe2bd530`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/06-platform-adapters`, not `main`. Prior phase reviews/promotions remain prerequisites, and this phase requires its own independent review before promotion. Live integration with the legacy fatwa system remains a Human Gate.