### PR TITLE
Phase 8 — Idempotent Publishing Dispatcher

### DIFF
--- a/app/domain/publishing.py
+++ b/app/domain/publishing.py
@@ -1,0 +1,57 @@
+"""Domain contracts for exact-source, idempotent origin publishing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from app.domain.events import OutboundAction, Platform
+
+
+class PublicationSourceKind(StrEnum):
+    """Authoritative durable source that supplied reply text."""
+
+    FAQ = "faq"
+    SUPERVISOR = "supervisor"
+    FATWA = "fatwa"
+
+
+class PublicationStatus(StrEnum):
+    """Allowed outbound action lifecycle for V1 publishing."""
+
+    PENDING = "pending"
+    DISPATCHING = "dispatching"
+    SUCCEEDED = "succeeded"
+    UNCERTAIN = "uncertain"
+
+
+class FatwaPublicationPolicy(StrEnum):
+    """Configured post-fatwa destination policy."""
+
+    TELEGRAM_ONLY = "telegram_only"
+    ORIGIN_ONLY = "origin_only"
+    BOTH = "both"
+
+    @property
+    def allows_origin_reply(self) -> bool:
+        return self in {self.ORIGIN_ONLY, self.BOTH}
+
+
+@dataclass(frozen=True, slots=True)
+class PublishableContent:
+    """Exact text plus immutable evidence identity selected for publication."""
+
+    event_id: str
+    platform: Platform
+    target_id: str
+    source_kind: PublicationSourceKind
+    evidence_id: str
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationResult:
+    """Durable action returned by the dispatcher and whether a provider was called."""
+
+    action: OutboundAction
+    provider_called: bool

--- a/app/persistence/publishing_repository.py
+++ b/app/persistence/publishing_repository.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from app.domain.events import OutboundAction, Platform
-from app.domain.publishing import PublicationSourceKind, PublicationStatus, PublishableContent
+from app.domain.publishing import PublicationStatus, PublishableContent
 from app.persistence.repositories import EventNotFound, IdempotencyConflict
 from app.persistence.sqlite import SQLiteDatabase
 

--- a/app/persistence/publishing_repository.py
+++ b/app/persistence/publishing_repository.py
@@ -1,0 +1,256 @@
+"""Atomic lifecycle operations for the durable outbound publication ledger."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.events import OutboundAction, Platform
+from app.domain.publishing import PublicationSourceKind, PublicationStatus, PublishableContent
+from app.persistence.repositories import EventNotFound, IdempotencyConflict
+from app.persistence.sqlite import SQLiteDatabase
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _action_from_row(row: sqlite3.Row) -> OutboundAction:
+    return OutboundAction(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        platform=Platform(str(row["platform"])),
+        action_type=str(row["action_type"]),
+        idempotency_key=str(row["idempotency_key"]),
+        status=str(row["status"]),
+        external_result_id=(
+            str(row["external_result_id"])
+            if row["external_result_id"] is not None
+            else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+        updated_at=_from_timestamp(str(row["updated_at"])),
+    )
+
+
+def _action_type(content: PublishableContent) -> str:
+    return f"reply:{content.source_kind.value}:{content.evidence_id}"
+
+
+def _idempotency_key(content: PublishableContent) -> str:
+    return (
+        f"publish:{content.event_id}:{content.platform.value}:"
+        f"{content.source_kind.value}:{content.evidence_id}"
+    )
+
+
+class PublishingRepository:
+    """Persist and atomically claim one exact-source publication intent."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def ensure_action(self, content: PublishableContent) -> OutboundAction:
+        """Create the durable intent before any external publisher is called."""
+
+        action_id = str(uuid4())
+        action_type = _action_type(content)
+        idempotency_key = _idempotency_key(content)
+        now = _utc_now()
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event = connection.execute(
+                "SELECT platform FROM inbound_events WHERE id = ?",
+                (content.event_id,),
+            ).fetchone()
+            if event is None:
+                connection.rollback()
+                raise EventNotFound(content.event_id)
+            if str(event["platform"]) != content.platform.value:
+                connection.rollback()
+                raise ValueError("publication platform does not match inbound event")
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO outbound_actions (
+                        id, event_id, platform, action_type, idempotency_key,
+                        status, external_result_id, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        action_id,
+                        content.event_id,
+                        content.platform.value,
+                        action_type,
+                        idempotency_key,
+                        PublicationStatus.PENDING.value,
+                        None,
+                        _to_timestamp(now),
+                        _to_timestamp(now),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM outbound_actions WHERE id = ?",
+                    (action_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted outbound action could not be reloaded")
+                return _action_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    "SELECT * FROM outbound_actions WHERE idempotency_key = ?",
+                    (idempotency_key,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _action_from_row(row)
+                if (
+                    existing.event_id != content.event_id
+                    or existing.platform is not content.platform
+                    or existing.action_type != action_type
+                ):
+                    raise IdempotencyConflict(
+                        "publication key is already bound to different semantics"
+                    ) from None
+                return existing
+
+    def claim(self, action_id: str) -> tuple[OutboundAction, bool]:
+        """Atomically move one pending action to dispatching for exactly one worker."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(action_id)
+            current = _action_from_row(row)
+            status = PublicationStatus(current.status)
+            if status is not PublicationStatus.PENDING:
+                connection.commit()
+                return current, False
+
+            now = _utc_now()
+            connection.execute(
+                "UPDATE outbound_actions SET status = ?, updated_at = ? WHERE id = ?",
+                (PublicationStatus.DISPATCHING.value, _to_timestamp(now), action_id),
+            )
+            updated = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("claimed outbound action could not be reloaded")
+        return _action_from_row(updated), True
+
+    def mark_succeeded(self, action_id: str, external_result_id: str) -> OutboundAction:
+        """Record a stable provider result after a claimed external call succeeds."""
+
+        result_id = external_result_id.strip()
+        if not result_id or any(char.isspace() for char in result_id):
+            raise ValueError("external_result_id must be a compact identifier")
+        if len(result_id) > 512:
+            raise ValueError("external_result_id exceeds maximum identifier length")
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(action_id)
+            current = _action_from_row(row)
+            status = PublicationStatus(current.status)
+            if status is PublicationStatus.SUCCEEDED:
+                connection.commit()
+                if current.external_result_id == result_id:
+                    return current
+                raise IdempotencyConflict(
+                    "succeeded publication is bound to a different provider result"
+                )
+            if status is not PublicationStatus.DISPATCHING:
+                connection.rollback()
+                raise ValueError("only dispatching action may become succeeded")
+
+            now = _utc_now()
+            connection.execute(
+                """
+                UPDATE outbound_actions
+                SET status = ?, external_result_id = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    PublicationStatus.SUCCEEDED.value,
+                    result_id,
+                    _to_timestamp(now),
+                    action_id,
+                ),
+            )
+            updated = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("succeeded outbound action could not be reloaded")
+        return _action_from_row(updated)
+
+    def mark_uncertain(self, action_id: str) -> OutboundAction:
+        """Freeze a started attempt whose external side-effect outcome is unknown."""
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise LookupError(action_id)
+            current = _action_from_row(row)
+            status = PublicationStatus(current.status)
+            if status is PublicationStatus.UNCERTAIN:
+                connection.commit()
+                return current
+            if status is not PublicationStatus.DISPATCHING:
+                connection.rollback()
+                raise ValueError("only dispatching action may become uncertain")
+
+            now = _utc_now()
+            connection.execute(
+                "UPDATE outbound_actions SET status = ?, updated_at = ? WHERE id = ?",
+                (PublicationStatus.UNCERTAIN.value, _to_timestamp(now), action_id),
+            )
+            updated = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            connection.commit()
+        if updated is None:
+            raise RuntimeError("uncertain outbound action could not be reloaded")
+        return _action_from_row(updated)
+
+    def count_actions(self) -> int:
+        """Return current outbound action count."""
+
+        with self.database.connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM outbound_actions").fetchone()
+        return int(row["count"]) if row is not None else 0

--- a/app/services/publishing.py
+++ b/app/services/publishing.py
@@ -1,0 +1,185 @@
+"""Exact-source publishing dispatcher with durable claim and uncertainty handling."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from app.adapters.contracts import ReplyPublisher
+from app.domain.classification import ClassificationRoute
+from app.domain.events import Platform
+from app.domain.faq import FAQEntryStatus, FAQResolutionStatus
+from app.domain.fatwa import FatwaBridgeStatus
+from app.domain.publishing import (
+    FatwaPublicationPolicy,
+    PublicationResult,
+    PublicationSourceKind,
+    PublicationStatus,
+    PublishableContent,
+)
+from app.domain.supervisor import SupervisorEscalationStatus
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.publishing_repository import PublishingRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.supervisor_repository import SupervisorRepository
+
+
+class PublishingNotEligible(RuntimeError):
+    """Raised when durable upstream evidence does not authorize publication."""
+
+
+class PublisherUnavailable(RuntimeError):
+    """Raised when no injected publisher exists for the event platform."""
+
+
+class PublicationInFlight(RuntimeError):
+    """Raised instead of calling a provider twice while another attempt is dispatching."""
+
+
+class PublicationUncertain(RuntimeError):
+    """Raised when an external call may have succeeded but durable confirmation is absent."""
+
+
+class PublishingService:
+    """Select exact approved text and dispatch it once through an injected publisher."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        classifications: ClassificationRepository,
+        faqs: FAQRepository,
+        supervisors: SupervisorRepository,
+        fatwas: FatwaRepository,
+        publications: PublishingRepository,
+        publishers: Mapping[Platform, ReplyPublisher],
+        fatwa_policy: FatwaPublicationPolicy = FatwaPublicationPolicy.TELEGRAM_ONLY,
+    ) -> None:
+        self.events = events
+        self.classifications = classifications
+        self.faqs = faqs
+        self.supervisors = supervisors
+        self.fatwas = fatwas
+        self.publications = publications
+        self.publishers = publishers
+        self.fatwa_policy = fatwa_policy
+
+    def resolve_content(self, event_id: str) -> PublishableContent:
+        """Resolve exact durable source text without generation or transformation."""
+
+        event = self.events.get_event(event_id)
+        if event.external_comment_id is None or not event.external_comment_id.strip():
+            raise PublishingNotEligible("origin event has no publishable reply target")
+        classification = self.classifications.get_for_event(event_id)
+        if classification is None:
+            raise PublishingNotEligible("publication requires durable classification evidence")
+
+        if classification.route is ClassificationRoute.FAQ:
+            resolution = self.faqs.get_resolution(event_id)
+            if resolution is None:
+                raise PublishingNotEligible("FAQ route has no durable resolution")
+            if resolution.status is FAQResolutionStatus.RESOLVED:
+                if resolution.faq_entry_id is None:
+                    raise PublishingNotEligible("resolved FAQ has no exact entry evidence")
+                entry = self.faqs.get_entry(resolution.faq_entry_id)
+                if entry.status is not FAQEntryStatus.ACTIVE:
+                    raise PublishingNotEligible("resolved FAQ entry has been revoked")
+                return PublishableContent(
+                    event_id=event.id,
+                    platform=event.platform,
+                    target_id=event.external_comment_id,
+                    source_kind=PublicationSourceKind.FAQ,
+                    evidence_id=f"{resolution.id}.{entry.id}",
+                    text=entry.answer_text,
+                )
+            return self._supervisor_content(event.id, event.platform, event.external_comment_id)
+
+        if classification.route is ClassificationRoute.SUPERVISOR:
+            return self._supervisor_content(event.id, event.platform, event.external_comment_id)
+
+        if classification.route is ClassificationRoute.FATWA:
+            if not self.fatwa_policy.allows_origin_reply:
+                raise PublishingNotEligible(
+                    "configured FATWA publication policy does not allow origin reply"
+                )
+            request = self.fatwas.get_for_event(event_id)
+            if request is None or request.status is not FatwaBridgeStatus.APPROVED_RESULT:
+                raise PublishingNotEligible("FATWA route has no approved external result")
+            result = self.fatwas.get_result(request.id)
+            if result is None or result.publishable_answer is None:
+                raise PublishingNotEligible("FATWA result is not publishable")
+            return PublishableContent(
+                event_id=event.id,
+                platform=event.platform,
+                target_id=event.external_comment_id,
+                source_kind=PublicationSourceKind.FATWA,
+                evidence_id=result.id,
+                text=result.publishable_answer,
+            )
+
+        raise PublishingNotEligible("unsupported classification route")
+
+    def _supervisor_content(
+        self,
+        event_id: str,
+        platform: Platform,
+        target_id: str,
+    ) -> PublishableContent:
+        escalation = self.supervisors.get_for_event(event_id)
+        if escalation is None or escalation.status is not SupervisorEscalationStatus.RESPONDED:
+            raise PublishingNotEligible("supervisor route has no accepted human response")
+        response = self.supervisors.get_response(escalation.id)
+        if response is None:
+            raise PublishingNotEligible("responded escalation is missing durable response")
+        return PublishableContent(
+            event_id=event_id,
+            platform=platform,
+            target_id=target_id,
+            source_kind=PublicationSourceKind.SUPERVISOR,
+            evidence_id=response.id,
+            text=response.text,
+        )
+
+    async def dispatch_origin(self, event_id: str) -> PublicationResult:
+        """Publish once or return/raise from durable state without blind retries."""
+
+        content = self.resolve_content(event_id)
+        publisher = self.publishers.get(content.platform)
+        if publisher is None:
+            raise PublisherUnavailable(f"no publisher configured for {content.platform.value}")
+
+        action = self.publications.ensure_action(content)
+        status = PublicationStatus(action.status)
+        if status is PublicationStatus.SUCCEEDED:
+            return PublicationResult(action=action, provider_called=False)
+        if status is PublicationStatus.UNCERTAIN:
+            raise PublicationUncertain("publication outcome requires reconciliation")
+        if status is PublicationStatus.DISPATCHING:
+            raise PublicationInFlight("publication is already being dispatched")
+
+        claimed, acquired = self.publications.claim(action.id)
+        if not acquired:
+            current_status = PublicationStatus(claimed.status)
+            if current_status is PublicationStatus.SUCCEEDED:
+                return PublicationResult(action=claimed, provider_called=False)
+            if current_status is PublicationStatus.UNCERTAIN:
+                raise PublicationUncertain("publication outcome requires reconciliation")
+            raise PublicationInFlight("publication is already being dispatched")
+
+        try:
+            external_result_id = await publisher.publish_reply(
+                external_comment_id=content.target_id,
+                text=content.text,
+            )
+            succeeded = self.publications.mark_succeeded(
+                claimed.id,
+                external_result_id,
+            )
+        except Exception:
+            self.publications.mark_uncertain(claimed.id)
+            raise PublicationUncertain(
+                "provider attempt began but outcome could not be confirmed"
+            ) from None
+
+        return PublicationResult(action=succeeded, provider_called=True)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,26 @@ A bridge result becomes publishable evidence only when the external result is `a
 
 ### Publishing dispatcher
 
-Publishing is separated from classification, FAQ resolution, supervisor response handling, and fatwa handling. A later dispatcher selects the correct Facebook/Instagram/Telegram/YouTube adapter and uses durable outbound action records to prevent duplicate publishing.
+Phase 8 implements exact-source, mock-first origin publishing. Publication is permitted only from one of three durable sources:
+
+- a `resolved` FAQ resolution whose exact referenced FAQ entry is still `active` at dispatch time;
+- a supervisor escalation in `responded` state with its single accepted human response;
+- a FATWA bridge request in `approved_result` state with attributed external approval evidence, and only when the explicit fatwa publication policy permits an origin reply.
+
+The dispatcher never generates, rewrites, summarizes, translates, or improves source text. The selected text is passed verbatim to the injected platform publisher.
+
+Outbound execution is crash-safe by policy:
+
+```text
+pending -> dispatching -> succeeded
+                └──────> uncertain
+```
+
+A durable `outbound_actions` intent is created before any provider call. A worker must atomically claim `pending -> dispatching` before invoking the publisher, preventing concurrent workers from both publishing the same semantic action. The deterministic idempotency key binds the event, destination platform, source kind, and exact durable evidence identity.
+
+If a provider call succeeds, the stable external result id is stored and later duplicate dispatch requests return the same durable `succeeded` action without another provider call. If an exception occurs after the provider attempt begins, the action becomes `uncertain`; it is never automatically retried because the external side effect may already have occurred. `dispatching` and `uncertain` require explicit reconciliation rather than blind resend.
+
+The default FATWA publication policy is `telegram_only`, so approved fatwa text is not automatically posted back to the origin comment unless a separate explicit policy configuration permits it. Phase 8 still uses injected/mock publishers only and performs no live platform publication.
 
 ## Reliability rules
 
@@ -161,7 +180,9 @@ Publishing is separated from classification, FAQ resolution, supervisor response
 - Inbound platform events are idempotent.
 - Moderation, classification, FAQ resolution, supervisor escalation, and fatwa bridge state are durable.
 - Duplicate/racing workers converge on one semantic durable result.
-- Outbound replies/actions are idempotent.
+- Outbound reply intents are persisted before external calls.
+- Concurrent publication workers cannot both claim the same pending action.
+- Provider-call uncertainty freezes the action for reconciliation instead of blind retry.
 - SQLite foreign keys are enabled.
 - WAL mode and busy timeout are enabled where safe.
 - External failure must not silently lose accepted work.
@@ -181,3 +202,4 @@ Publishing is separated from classification, FAQ resolution, supervisor response
 - Phase 5: durable human supervisor escalation/response workflow; no live Telegram calls.
 - Phase 6: mock-first four-platform normalizers and injected publisher/transport clients; no live network clients.
 - Phase 7: durable supervised fatwa bridge request/result lifecycle; no legacy-bot call or modification.
+- Phase 8: exact-source crash-safe publishing dispatcher with atomic claim and uncertainty freeze; injected publishers only, no live publication.

--- a/prompts/08_PHASE8_PUBLISHING_DISPATCHER.md
+++ b/prompts/08_PHASE8_PUBLISHING_DISPATCHER.md
@@ -1,0 +1,51 @@
+# Phase 8 — Idempotent Publishing Dispatcher
+
+## Objective
+
+Build a mock-first dispatcher that publishes only exact durable content already authorized by upstream evidence. It must not generate or transform reply text.
+
+## Authoritative content sources
+
+- FAQ: `resolved` FAQ resolution and the exact referenced FAQ entry must still be `active` at dispatch time.
+- Supervisor: escalation must be `responded` and have exactly one accepted durable human response.
+- FATWA: bridge request must be `approved_result` and have an attributed approved external result.
+
+Anything else is not publishable.
+
+## Origin publishing
+
+Origin reply requires a non-empty `external_comment_id`. Select publisher strictly by the event's V1 platform. Publishers are injected protocols only; tests use fakes and this phase adds no production clients.
+
+## Durable action lifecycle
+
+Use `outbound_actions` as the pre/post external-action ledger:
+
+- `pending`: durable intent exists, provider has not been called;
+- `dispatching`: one worker atomically owns the external attempt;
+- `succeeded`: stable provider result id recorded;
+- `uncertain`: provider call raised after attempt began, so side effect is unknown.
+
+Never automatically resend `dispatching`, `succeeded`, or `uncertain` actions. An `uncertain` action requires later reconciliation/human handling; blindly retrying can duplicate replies.
+
+The deterministic idempotency key must bind event, platform, source kind, and exact source evidence id. Concurrent callers must produce at most one publisher call.
+
+## FATWA publication policy
+
+Represent explicit values `telegram_only`, `origin_only`, and `both`. Default is `telegram_only`. This dispatcher only handles the origin-reply side, so a FATWA result is eligible for origin publication only under `origin_only` or `both`. Changing the production policy remains a Human Gate.
+
+## Safety
+
+- no live APIs, tokens, OAuth, webhooks, polling, or production endpoints;
+- no generated, rewritten, summarized, translated, or improved source text;
+- revoked FAQ entries are blocked at dispatch time;
+- no unapproved/rejected FATWA answer is exposed;
+- no supervisor reply before a durable human response;
+- no automatic retry after uncertain external outcome;
+- no raw exception text persisted.
+
+## Gates
+
+- `ruff check app tests`
+- `mypy app`
+- `pytest`
+- independent review before promotion

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -77,7 +77,12 @@ class Fixture:
             )
         ).event.id
 
-    def classify(self, event_id: str, route: ClassificationRoute, faq_key: str | None = None) -> None:
+    def classify(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+        faq_key: str | None = None,
+    ) -> None:
         if route is ClassificationRoute.FAQ:
             decision = ClassificationDecision(
                 route=route,

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.adapters.contracts import ReplyPublisher
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.fatwa import FatwaResultOutcome
+from app.domain.publishing import FatwaPublicationPolicy, PublicationStatus
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.publishing_repository import PublishingRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.persistence.supervisor_repository import SupervisorRepository
+from app.services.faq import FAQService
+from app.services.fatwa import FatwaService
+from app.services.ingestion import IngestionService
+from app.services.publishing import (
+    PublicationInFlight,
+    PublicationUncertain,
+    PublishingNotEligible,
+    PublishingService,
+)
+from app.services.supervisor import SupervisorService
+
+
+class FakePublisher:
+    def __init__(self, *, fail: bool = False, delay: float = 0.0) -> None:
+        self.fail = fail
+        self.delay = delay
+        self.calls: list[tuple[str, str]] = []
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        self.calls.append((external_comment_id, text))
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.fail:
+            raise RuntimeError("Bearer secret-that-must-not-drive-a-retry")
+        return f"external-{external_comment_id}"
+
+
+class Fixture:
+    def __init__(self, tmp_path: Path) -> None:
+        self.database = SQLiteDatabase(tmp_path / "router.db")
+        self.database.initialize()
+        self.events = DurableRepository(self.database)
+        self.classifications = ClassificationRepository(self.database)
+        self.faqs = FAQRepository(self.database)
+        self.supervisors = SupervisorRepository(self.database)
+        self.fatwas = FatwaRepository(self.database)
+        self.publications = PublishingRepository(self.database)
+
+    def ingest(
+        self,
+        *,
+        key: str,
+        platform: Platform = Platform.FACEBOOK,
+        text: str = "سؤال",
+        target: str | None = "comment-1",
+    ) -> str:
+        return IngestionService(self.events).ingest_event(
+            NormalizedInboundEvent(
+                platform=platform,
+                external_event_key=key,
+                external_comment_id=target,
+                text=text,
+            )
+        ).event.id
+
+    def classify(self, event_id: str, route: ClassificationRoute, faq_key: str | None = None) -> None:
+        if route is ClassificationRoute.FAQ:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.CONFIDENT_FAQ,),
+                faq_key=faq_key or "fixture.key",
+            )
+            religious = False
+        elif route is ClassificationRoute.SUPERVISOR:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+            )
+            religious = False
+        else:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+            )
+            religious = True
+        self.classifications.create_for_event(
+            event_id=event_id,
+            decision=decision,
+            religious_possible=religious,
+            confidence=0.99,
+            adapter_name="test-classifier",
+            adapter_version="1",
+        )
+
+    def service(
+        self,
+        publisher: ReplyPublisher,
+        *,
+        platform: Platform = Platform.FACEBOOK,
+        fatwa_policy: FatwaPublicationPolicy = FatwaPublicationPolicy.TELEGRAM_ONLY,
+    ) -> PublishingService:
+        return PublishingService(
+            events=self.events,
+            classifications=self.classifications,
+            faqs=self.faqs,
+            supervisors=self.supervisors,
+            fatwas=self.fatwas,
+            publications=self.publications,
+            publishers={platform: publisher},
+            fatwa_policy=fatwa_policy,
+        )
+
+
+def _prepare_faq(fx: Fixture, event_id: str, answer: str = "الجواب المعتمد") -> str:
+    fx.classify(event_id, ClassificationRoute.FAQ, faq_key="registration.status")
+    entry = fx.faqs.create_version(
+        faq_key="registration.status",
+        answer_text=answer,
+        source_ref="fixture://faq/registration",
+        approved_by="reviewer-1",
+        approved_at=datetime(2026, 9, 10, 8, 0, tzinfo=UTC),
+    )
+    FAQService(classifications=fx.classifications, faqs=fx.faqs).resolve(event_id)
+    return entry.id
+
+
+def _prepare_supervisor(fx: Fixture, event_id: str, answer: str = "رد المشرف") -> None:
+    fx.classify(event_id, ClassificationRoute.SUPERVISOR)
+    service = SupervisorService(
+        events=fx.events,
+        classifications=fx.classifications,
+        faqs=fx.faqs,
+        supervisors=fx.supervisors,
+    )
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id=f"thread-{event_id}",
+    )
+    service.accept_response(
+        event_id,
+        external_response_key=f"response-{event_id}",
+        supervisor_ref="supervisor-1",
+        text=answer,
+        received_at=datetime(2026, 9, 10, 8, 5, tzinfo=UTC),
+    )
+
+
+def _prepare_fatwa(fx: Fixture, event_id: str, answer: str = "جواب شرعي معتمد") -> None:
+    fx.classify(event_id, ClassificationRoute.FATWA)
+    service = FatwaService(
+        events=fx.events,
+        classifications=fx.classifications,
+        fatwas=fx.fatwas,
+    )
+    service.mark_dispatched(
+        event_id,
+        bridge_name="supervised-fatwa-system",
+        external_case_id=f"case-{event_id}",
+    )
+    service.accept_result(
+        event_id,
+        external_result_key=f"result-{event_id}",
+        outcome=FatwaResultOutcome.APPROVED,
+        answer_text=answer,
+        approved_by="scholar-reviewer-1",
+        source_ref=f"fixture://fatwa/{event_id}",
+        received_at=datetime(2026, 9, 10, 8, 10, tzinfo=UTC),
+    )
+
+
+def test_faq_publishes_exact_active_approved_text(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="faq", target="fb-comment-1")
+    answer = "النص المعتمد كما هو، دون إعادة صياغة."
+    _prepare_faq(fx, event_id, answer)
+    publisher = FakePublisher()
+
+    result = asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert result.provider_called is True
+    assert result.action.status == PublicationStatus.SUCCEEDED.value
+    assert publisher.calls == [("fb-comment-1", answer)]
+
+
+def test_revoked_faq_is_blocked_before_publisher_call(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="faq-revoked")
+    _prepare_faq(fx, event_id)
+    fx.faqs.disable_active("registration.status")
+    publisher = FakePublisher()
+
+    with pytest.raises(PublishingNotEligible, match="revoked"):
+        asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert publisher.calls == []
+    assert fx.publications.count_actions() == 0
+
+
+def test_supervisor_publishes_exact_human_response(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="supervisor", target="fb-comment-2")
+    answer = "هذا رد بشري معتمد حرفيًا."
+    _prepare_supervisor(fx, event_id, answer)
+    publisher = FakePublisher()
+
+    asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert publisher.calls == [("fb-comment-2", answer)]
+
+
+def test_fatwa_origin_is_blocked_by_default_policy(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="fatwa-default")
+    _prepare_fatwa(fx, event_id)
+    publisher = FakePublisher()
+
+    with pytest.raises(PublishingNotEligible, match="policy"):
+        asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert publisher.calls == []
+    assert fx.publications.count_actions() == 0
+
+
+def test_fatwa_origin_policy_can_publish_only_exact_external_approved_text(
+    tmp_path: Path,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="fatwa-origin", target="fb-comment-fatwa")
+    answer = "نص الجواب القادم من الجهة الشرعية دون تعديل."
+    _prepare_fatwa(fx, event_id, answer)
+    publisher = FakePublisher()
+    service = fx.service(
+        publisher,
+        fatwa_policy=FatwaPublicationPolicy.ORIGIN_ONLY,
+    )
+
+    asyncio.run(service.dispatch_origin(event_id))
+
+    assert publisher.calls == [("fb-comment-fatwa", answer)]
+
+
+def test_missing_origin_target_is_not_publishable(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="no-target", target=None)
+    _prepare_supervisor(fx, event_id)
+    publisher = FakePublisher()
+
+    with pytest.raises(PublishingNotEligible, match="target"):
+        asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert publisher.calls == []
+
+
+def test_duplicate_after_success_does_not_call_provider_twice(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="duplicate-success")
+    _prepare_supervisor(fx, event_id)
+    publisher = FakePublisher()
+    service = fx.service(publisher)
+
+    first = asyncio.run(service.dispatch_origin(event_id))
+    second = asyncio.run(service.dispatch_origin(event_id))
+
+    assert first.action.id == second.action.id
+    assert first.provider_called is True
+    assert second.provider_called is False
+    assert len(publisher.calls) == 1
+    assert fx.publications.count_actions() == 1
+
+
+def test_provider_exception_becomes_uncertain_and_is_never_blindly_retried(
+    tmp_path: Path,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="uncertain")
+    _prepare_supervisor(fx, event_id)
+    publisher = FakePublisher(fail=True)
+    service = fx.service(publisher)
+
+    with pytest.raises(PublicationUncertain):
+        asyncio.run(service.dispatch_origin(event_id))
+    with pytest.raises(PublicationUncertain, match="reconciliation"):
+        asyncio.run(service.dispatch_origin(event_id))
+
+    assert len(publisher.calls) == 1
+    with fx.database.connect() as connection:
+        row = connection.execute("SELECT status FROM outbound_actions").fetchone()
+    assert row is not None
+    assert row["status"] == PublicationStatus.UNCERTAIN.value
+
+
+def test_concurrent_dispatch_calls_make_at_most_one_provider_call(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="concurrent")
+    _prepare_supervisor(fx, event_id)
+    publisher = FakePublisher(delay=0.03)
+    service = fx.service(publisher)
+
+    async def run_two() -> list[object]:
+        return await asyncio.gather(
+            service.dispatch_origin(event_id),
+            service.dispatch_origin(event_id),
+            return_exceptions=True,
+        )
+
+    outcomes = asyncio.run(run_two())
+
+    assert len(publisher.calls) == 1
+    assert fx.publications.count_actions() == 1
+    assert any(not isinstance(item, Exception) for item in outcomes)
+    assert any(isinstance(item, PublicationInFlight) for item in outcomes)
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_all_v1_platforms_select_matching_injected_publisher(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(
+        key=f"platform-{platform.value}",
+        platform=platform,
+        target=f"target-{platform.value}",
+    )
+    _prepare_supervisor(fx, event_id, answer=f"رد {platform.value}")
+    publisher = FakePublisher()
+
+    asyncio.run(fx.service(publisher, platform=platform).dispatch_origin(event_id))
+
+    assert publisher.calls == [(f"target-{platform.value}", f"رد {platform.value}")]
+
+
+def test_publication_action_binds_exact_source_evidence(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="evidence-key")
+    _prepare_supervisor(fx, event_id)
+    publisher = FakePublisher()
+
+    result = asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    response = fx.supervisors.get_response(fx.supervisors.get_for_event(event_id).id)  # type: ignore[union-attr]
+    assert response is not None
+    assert response.id in result.action.action_type
+    assert response.id in result.action.idempotency_key
+    assert event_id in result.action.idempotency_key
+
+
+def test_no_publishable_evidence_creates_no_outbound_action(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="not-ready")
+    fx.classify(event_id, ClassificationRoute.SUPERVISOR)
+    publisher = FakePublisher()
+
+    with pytest.raises(PublishingNotEligible):
+        asyncio.run(fx.service(publisher).dispatch_origin(event_id))
+
+    assert fx.publications.count_actions() == 0
+    assert publisher.calls == []


### PR DESCRIPTION
## Summary

Implements Issue #20 as a stacked Phase 8 change above the durable Fatwa Bridge.

### Added
- exact-source publication selection from approved FAQ, accepted supervisor response, or approved attributed FATWA result only
- no text generation, rewriting, summarization, translation, or improvement in the publishing path
- deterministic outbound idempotency keys bound to event, destination platform, source kind, and exact durable evidence
- durable outbound intent created before any provider call
- atomic `pending -> dispatching` claim so concurrent workers cannot both call a publisher
- `succeeded` persistence with stable external result id
- `uncertain` freeze after an exception once a provider attempt has begun; no blind retry
- duplicate post-success dispatch returns existing durable action without a second provider call
- all four V1 platforms dispatched only through injected mock-first publishers
- explicit FATWA publication policy with safe default `telegram_only`
- revoked FAQ, missing supervisor response, unapproved FATWA, missing reply target, and unavailable publisher all fail closed

### Safety
- no live API calls, OAuth, webhooks, tokens, or production endpoints
- no generated religious content
- no automatic FATWA origin reply under the default policy
- no hide/delete/report side effects
- no raw provider payload persistence

### Validation
GitHub Actions run `34454488260` on head `afa76965fdec45d5b45ab947d10cb083ed67b8d4`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/07-fatwa-bridge`, not `main`. Prior phase reviews/promotions remain prerequisites. Phase 8 requires an independent adversarial review before promotion; live publication remains a separate Human Gate.