### PR TITLE
Phase 9 — Shadow Mode Evaluation & Audit

### DIFF
--- a/app/domain/shadow.py
+++ b/app/domain/shadow.py
@@ -1,0 +1,83 @@
+"""Side-effect-free shadow evaluation domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from app.domain.classification import ClassificationRoute
+from app.domain.events import Platform
+from app.domain.publishing import PublicationSourceKind
+
+
+class ShadowOutcome(StrEnum):
+    """Normalized outcome produced without taking any external action."""
+
+    WOULD_PUBLISH = "would_publish"
+    WOULD_WAIT_HUMAN = "would_wait_human"
+    WOULD_ROUTE_FATWA = "would_route_fatwa"
+    NOT_READY = "not_ready"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDecision:
+    """One deterministic, side-effect-free observation before persistence."""
+
+    event_id: str
+    correlation_id: str
+    platform: Platform
+    evaluator_version: str
+    observed_route: ClassificationRoute | None
+    outcome: ShadowOutcome
+    source_kind: PublicationSourceKind | None = None
+    evidence_id: str | None = None
+    proposed_text: str | None = None
+
+    def __post_init__(self) -> None:
+        version = self.evaluator_version.strip()
+        if not version or len(version) > 80 or any(char.isspace() for char in version):
+            raise ValueError("evaluator_version must be a compact identifier up to 80 characters")
+        if not self.correlation_id.strip():
+            raise ValueError("correlation_id must not be empty")
+
+        publish_fields = (self.source_kind, self.evidence_id, self.proposed_text)
+        if self.outcome is ShadowOutcome.WOULD_PUBLISH:
+            if any(value is None for value in publish_fields):
+                raise ValueError("would_publish requires exact source evidence and text")
+            assert self.evidence_id is not None
+            assert self.proposed_text is not None
+            if not self.evidence_id.strip() or not self.proposed_text.strip():
+                raise ValueError("would_publish evidence and text must not be empty")
+        elif any(value is not None for value in publish_fields):
+            raise ValueError("non-publish shadow outcomes cannot carry publishable content")
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowEvaluation:
+    """Persisted immutable shadow audit result."""
+
+    id: str
+    event_id: str
+    correlation_id: str
+    platform: Platform
+    evaluator_version: str
+    observed_route: ClassificationRoute | None
+    outcome: ShadowOutcome
+    source_kind: PublicationSourceKind | None
+    evidence_id: str | None
+    proposed_text: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowSummary:
+    """Aggregate shadow metrics that expose no user message content."""
+
+    total_evaluated: int
+    by_platform: dict[str, int]
+    by_route: dict[str, int]
+    by_outcome: dict[str, int]
+    publishable: int
+    non_publishable: int

--- a/app/persistence/schema.py
+++ b/app/persistence/schema.py
@@ -297,4 +297,63 @@ CREATE TABLE IF NOT EXISTS fatwa_bridge_results (
 
 CREATE INDEX IF NOT EXISTS idx_fatwa_bridge_results_received
 ON fatwa_bridge_results (received_at);
+
+CREATE TABLE IF NOT EXISTS shadow_evaluations (
+    id TEXT PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    correlation_id TEXT NOT NULL CHECK (length(trim(correlation_id)) > 0),
+    platform TEXT NOT NULL CHECK (
+        platform IN ('facebook', 'instagram', 'telegram', 'youtube')
+    ),
+    evaluator_version TEXT NOT NULL CHECK (
+        length(trim(evaluator_version)) > 0
+        AND length(evaluator_version) <= 80
+    ),
+    observed_route TEXT CHECK (
+        observed_route IS NULL OR observed_route IN ('FAQ', 'SUPERVISOR', 'FATWA')
+    ),
+    outcome TEXT NOT NULL CHECK (
+        outcome IN (
+            'would_publish',
+            'would_wait_human',
+            'would_route_fatwa',
+            'not_ready',
+            'blocked'
+        )
+    ),
+    source_kind TEXT CHECK (
+        source_kind IS NULL OR source_kind IN ('faq', 'supervisor', 'fatwa')
+    ),
+    evidence_id TEXT,
+    proposed_text TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES inbound_events(id) ON DELETE CASCADE,
+    UNIQUE (event_id, evaluator_version),
+    CHECK (
+        (
+            outcome = 'would_publish'
+            AND source_kind IS NOT NULL
+            AND evidence_id IS NOT NULL
+            AND length(trim(evidence_id)) > 0
+            AND proposed_text IS NOT NULL
+            AND length(trim(proposed_text)) > 0
+        )
+        OR
+        (
+            outcome != 'would_publish'
+            AND source_kind IS NULL
+            AND evidence_id IS NULL
+            AND proposed_text IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_shadow_evaluations_outcome
+ON shadow_evaluations (outcome, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_shadow_evaluations_platform
+ON shadow_evaluations (platform, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_shadow_evaluations_route
+ON shadow_evaluations (observed_route, created_at);
 """

--- a/app/persistence/shadow_repository.py
+++ b/app/persistence/shadow_repository.py
@@ -1,0 +1,226 @@
+"""Durable, idempotent persistence for side-effect-free shadow evaluations."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.classification import ClassificationRoute
+from app.domain.events import Platform
+from app.domain.publishing import PublicationSourceKind
+from app.domain.shadow import ShadowDecision, ShadowEvaluation, ShadowOutcome, ShadowSummary
+from app.persistence.repositories import EventNotFound
+from app.persistence.sqlite import SQLiteDatabase
+
+
+class ShadowConflict(RuntimeError):
+    """Raised when an event/version key is reused for different shadow semantics."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _evaluation_from_row(row: sqlite3.Row) -> ShadowEvaluation:
+    route = row["observed_route"]
+    source_kind = row["source_kind"]
+    return ShadowEvaluation(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        correlation_id=str(row["correlation_id"]),
+        platform=Platform(str(row["platform"])),
+        evaluator_version=str(row["evaluator_version"]),
+        observed_route=(ClassificationRoute(str(route)) if route is not None else None),
+        outcome=ShadowOutcome(str(row["outcome"])),
+        source_kind=(
+            PublicationSourceKind(str(source_kind)) if source_kind is not None else None
+        ),
+        evidence_id=(str(row["evidence_id"]) if row["evidence_id"] is not None else None),
+        proposed_text=(
+            str(row["proposed_text"]) if row["proposed_text"] is not None else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+def _matches(existing: ShadowEvaluation, decision: ShadowDecision) -> bool:
+    return (
+        existing.event_id == decision.event_id
+        and existing.correlation_id == decision.correlation_id
+        and existing.platform is decision.platform
+        and existing.evaluator_version == decision.evaluator_version.strip()
+        and existing.observed_route is decision.observed_route
+        and existing.outcome is decision.outcome
+        and existing.source_kind is decision.source_kind
+        and existing.evidence_id == decision.evidence_id
+        and existing.proposed_text == decision.proposed_text
+    )
+
+
+class ShadowRepository:
+    """Store one immutable evaluation per event and evaluator version."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def get(self, event_id: str, evaluator_version: str) -> ShadowEvaluation | None:
+        """Return one previously persisted evaluation."""
+
+        version = evaluator_version.strip()
+        with self.database.connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM shadow_evaluations
+                WHERE event_id = ? AND evaluator_version = ?
+                """,
+                (event_id, version),
+            ).fetchone()
+        return _evaluation_from_row(row) if row is not None else None
+
+    def record(self, decision: ShadowDecision) -> ShadowEvaluation:
+        """Persist a shadow decision or return the identical winner of a duplicate race."""
+
+        evaluation_id = str(uuid4())
+        version = decision.evaluator_version.strip()
+        now = _utc_now()
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            event = connection.execute(
+                "SELECT platform, correlation_id FROM inbound_events WHERE id = ?",
+                (decision.event_id,),
+            ).fetchone()
+            if event is None:
+                connection.rollback()
+                raise EventNotFound(decision.event_id)
+            if (
+                str(event["platform"]) != decision.platform.value
+                or str(event["correlation_id"]) != decision.correlation_id
+            ):
+                connection.rollback()
+                raise ValueError("shadow decision identity does not match durable event")
+
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO shadow_evaluations (
+                        id, event_id, correlation_id, platform, evaluator_version,
+                        observed_route, outcome, source_kind, evidence_id,
+                        proposed_text, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        evaluation_id,
+                        decision.event_id,
+                        decision.correlation_id,
+                        decision.platform.value,
+                        version,
+                        (
+                            decision.observed_route.value
+                            if decision.observed_route is not None
+                            else None
+                        ),
+                        decision.outcome.value,
+                        (
+                            decision.source_kind.value
+                            if decision.source_kind is not None
+                            else None
+                        ),
+                        decision.evidence_id,
+                        decision.proposed_text,
+                        _to_timestamp(now),
+                    ),
+                )
+                row = connection.execute(
+                    "SELECT * FROM shadow_evaluations WHERE id = ?",
+                    (evaluation_id,),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise RuntimeError("inserted shadow evaluation could not be reloaded")
+                return _evaluation_from_row(row)
+            except sqlite3.IntegrityError:
+                row = connection.execute(
+                    """
+                    SELECT * FROM shadow_evaluations
+                    WHERE event_id = ? AND evaluator_version = ?
+                    """,
+                    (decision.event_id, version),
+                ).fetchone()
+                connection.commit()
+                if row is None:
+                    raise
+                existing = _evaluation_from_row(row)
+                if not _matches(existing, decision):
+                    raise ShadowConflict(
+                        "event/evaluator version is already bound to different evidence"
+                    ) from None
+                return existing
+
+    def count(self) -> int:
+        """Return the number of persisted shadow evaluations."""
+
+        with self.database.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) AS count FROM shadow_evaluations"
+            ).fetchone()
+        return int(row["count"]) if row is not None else 0
+
+    def summary(self) -> ShadowSummary:
+        """Return aggregate metrics without exposing proposed reply text."""
+
+        with self.database.connect() as connection:
+            total_row = connection.execute(
+                "SELECT COUNT(*) AS count FROM shadow_evaluations"
+            ).fetchone()
+            platform_rows = connection.execute(
+                """
+                SELECT platform, COUNT(*) AS count
+                FROM shadow_evaluations GROUP BY platform ORDER BY platform
+                """
+            ).fetchall()
+            route_rows = connection.execute(
+                """
+                SELECT observed_route, COUNT(*) AS count
+                FROM shadow_evaluations GROUP BY observed_route ORDER BY observed_route
+                """
+            ).fetchall()
+            outcome_rows = connection.execute(
+                """
+                SELECT outcome, COUNT(*) AS count
+                FROM shadow_evaluations GROUP BY outcome ORDER BY outcome
+                """
+            ).fetchall()
+            publish_row = connection.execute(
+                """
+                SELECT COUNT(*) AS count FROM shadow_evaluations
+                WHERE outcome = 'would_publish'
+                """
+            ).fetchone()
+
+        total = int(total_row["count"]) if total_row is not None else 0
+        publishable = int(publish_row["count"]) if publish_row is not None else 0
+        by_platform = {str(row["platform"]): int(row["count"]) for row in platform_rows}
+        by_route = {
+            (str(row["observed_route"]) if row["observed_route"] is not None else "none"):
+            int(row["count"])
+            for row in route_rows
+        }
+        by_outcome = {str(row["outcome"]): int(row["count"]) for row in outcome_rows}
+        return ShadowSummary(
+            total_evaluated=total,
+            by_platform=by_platform,
+            by_route=by_route,
+            by_outcome=by_outcome,
+            publishable=publishable,
+            non_publishable=total - publishable,
+        )

--- a/app/services/shadow.py
+++ b/app/services/shadow.py
@@ -47,7 +47,6 @@ class ShadowService:
     def evaluate(self, event_id: str) -> ShadowEvaluation:
         """Compute and persist one immutable shadow observation for an event."""
 
-        event = self.events.get_event(event_id)
         moderation = self.moderation.get_for_event(event_id)
 
         if moderation is None:

--- a/app/services/shadow.py
+++ b/app/services/shadow.py
@@ -1,0 +1,186 @@
+"""Side-effect-free evaluation of durable Gheras routing and reply evidence."""
+
+from __future__ import annotations
+
+from app.domain.classification import ClassificationRoute
+from app.domain.faq import FAQEntryStatus, FAQResolutionStatus
+from app.domain.fatwa import FatwaBridgeStatus
+from app.domain.moderation import ModerationDisposition
+from app.domain.publishing import FatwaPublicationPolicy, PublicationSourceKind
+from app.domain.shadow import ShadowDecision, ShadowEvaluation, ShadowOutcome, ShadowSummary
+from app.domain.supervisor import SupervisorEscalationStatus
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.shadow_repository import ShadowRepository
+from app.persistence.supervisor_repository import SupervisorRepository
+
+
+class ShadowService:
+    """Evaluate what durable evidence permits without invoking any external adapter."""
+
+    def __init__(
+        self,
+        *,
+        events: DurableRepository,
+        moderation: ModerationRepository,
+        classifications: ClassificationRepository,
+        faqs: FAQRepository,
+        supervisors: SupervisorRepository,
+        fatwas: FatwaRepository,
+        shadows: ShadowRepository,
+        evaluator_version: str = "shadow-v1",
+        fatwa_policy: FatwaPublicationPolicy = FatwaPublicationPolicy.TELEGRAM_ONLY,
+    ) -> None:
+        self.events = events
+        self.moderation = moderation
+        self.classifications = classifications
+        self.faqs = faqs
+        self.supervisors = supervisors
+        self.fatwas = fatwas
+        self.shadows = shadows
+        self.evaluator_version = evaluator_version
+        self.fatwa_policy = fatwa_policy
+
+    def evaluate(self, event_id: str) -> ShadowEvaluation:
+        """Compute and persist one immutable shadow observation for an event."""
+
+        event = self.events.get_event(event_id)
+        moderation = self.moderation.get_for_event(event_id)
+
+        if moderation is None:
+            return self._record(event_id, ShadowOutcome.NOT_READY)
+        if moderation.disposition is ModerationDisposition.BLOCK_ROUTING:
+            return self._record(event_id, ShadowOutcome.BLOCKED)
+        if moderation.disposition is ModerationDisposition.HUMAN_REVIEW:
+            return self._record(event_id, ShadowOutcome.WOULD_WAIT_HUMAN)
+
+        classification = self.classifications.get_for_event(event_id)
+        if classification is None:
+            return self._record(event_id, ShadowOutcome.NOT_READY)
+
+        route = classification.route
+        if route is ClassificationRoute.FAQ:
+            return self._evaluate_faq(event_id, route)
+        if route is ClassificationRoute.SUPERVISOR:
+            return self._evaluate_supervisor(event_id, route)
+        if route is ClassificationRoute.FATWA:
+            return self._evaluate_fatwa(event_id, route)
+        return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+
+    def summary(self) -> ShadowSummary:
+        """Return content-free aggregate metrics for all persisted shadow evaluations."""
+
+        return self.shadows.summary()
+
+    def _evaluate_faq(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+    ) -> ShadowEvaluation:
+        resolution = self.faqs.get_resolution(event_id)
+        if resolution is None:
+            return self._record(event_id, ShadowOutcome.NOT_READY, route=route)
+
+        if resolution.status is FAQResolutionStatus.RESOLVED:
+            if resolution.faq_entry_id is None:
+                return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+            try:
+                entry = self.faqs.get_entry(resolution.faq_entry_id)
+            except LookupError:
+                return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+            if entry.status is not FAQEntryStatus.ACTIVE:
+                return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+            return self._record(
+                event_id,
+                ShadowOutcome.WOULD_PUBLISH,
+                route=route,
+                source_kind=PublicationSourceKind.FAQ,
+                evidence_id=f"{resolution.id}.{entry.id}",
+                proposed_text=entry.answer_text,
+            )
+
+        return self._evaluate_supervisor(event_id, route)
+
+    def _evaluate_supervisor(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+    ) -> ShadowEvaluation:
+        escalation = self.supervisors.get_for_event(event_id)
+        if escalation is None:
+            return self._record(event_id, ShadowOutcome.WOULD_WAIT_HUMAN, route=route)
+        if escalation.status is SupervisorEscalationStatus.CANCELLED:
+            return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+        if escalation.status is not SupervisorEscalationStatus.RESPONDED:
+            return self._record(event_id, ShadowOutcome.WOULD_WAIT_HUMAN, route=route)
+
+        response = self.supervisors.get_response(escalation.id)
+        if response is None:
+            return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+        return self._record(
+            event_id,
+            ShadowOutcome.WOULD_PUBLISH,
+            route=route,
+            source_kind=PublicationSourceKind.SUPERVISOR,
+            evidence_id=response.id,
+            proposed_text=response.text,
+        )
+
+    def _evaluate_fatwa(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+    ) -> ShadowEvaluation:
+        request = self.fatwas.get_for_event(event_id)
+        if request is None:
+            return self._record(event_id, ShadowOutcome.WOULD_ROUTE_FATWA, route=route)
+        if request.status in {
+            FatwaBridgeStatus.PENDING_DISPATCH,
+            FatwaBridgeStatus.AWAITING_RESULT,
+        }:
+            return self._record(event_id, ShadowOutcome.WOULD_ROUTE_FATWA, route=route)
+        if request.status in {FatwaBridgeStatus.REJECTED, FatwaBridgeStatus.CANCELLED}:
+            return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+        if request.status is not FatwaBridgeStatus.APPROVED_RESULT:
+            return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+
+        result = self.fatwas.get_result(request.id)
+        if result is None or result.publishable_answer is None:
+            return self._record(event_id, ShadowOutcome.BLOCKED, route=route)
+        if not self.fatwa_policy.allows_origin_reply:
+            return self._record(event_id, ShadowOutcome.WOULD_ROUTE_FATWA, route=route)
+        return self._record(
+            event_id,
+            ShadowOutcome.WOULD_PUBLISH,
+            route=route,
+            source_kind=PublicationSourceKind.FATWA,
+            evidence_id=result.id,
+            proposed_text=result.publishable_answer,
+        )
+
+    def _record(
+        self,
+        event_id: str,
+        outcome: ShadowOutcome,
+        *,
+        route: ClassificationRoute | None = None,
+        source_kind: PublicationSourceKind | None = None,
+        evidence_id: str | None = None,
+        proposed_text: str | None = None,
+    ) -> ShadowEvaluation:
+        event = self.events.get_event(event_id)
+        decision = ShadowDecision(
+            event_id=event.id,
+            correlation_id=event.correlation_id,
+            platform=event.platform,
+            evaluator_version=self.evaluator_version,
+            observed_route=route,
+            outcome=outcome,
+            source_kind=source_kind,
+            evidence_id=evidence_id,
+            proposed_text=proposed_text,
+        )
+        return self.shadows.record(decision)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,8 @@ YouTube   ─┘                                                                
                                                          Facebook     Instagram    Telegram    YouTube
 ```
 
+Shadow Mode observes the same durable decision evidence in a separate read/audit path and performs no publication or transport action.
+
 ## Boundaries
 
 ### HTTP application
@@ -57,6 +59,7 @@ The SQLite durable layer contains persistent concerns including:
 - `supervisor_responses`: one accepted human response per escalation.
 - `fatwa_bridge_requests`: one durable supervised-fatwa request per FATWA event.
 - `fatwa_bridge_results`: one normalized attributed external result per bridge request.
+- `shadow_evaluations`: immutable side-effect-free observations keyed by event and evaluator version.
 
 Inbound uniqueness is `(platform, external_event_key)`. Outbound uniqueness is `idempotency_key`. Duplicate work must resolve to the existing durable record instead of creating a second semantic action.
 
@@ -174,15 +177,37 @@ If a provider call succeeds, the stable external result id is stored and later d
 
 The default FATWA publication policy is `telegram_only`, so approved fatwa text is not automatically posted back to the origin comment unless a separate explicit policy configuration permits it. Phase 8 still uses injected/mock publishers only and performs no live platform publication.
 
+### Shadow Mode boundary
+
+Phase 9 adds an evaluation-only path over the durable evidence produced by earlier phases. `ShadowService` has no publisher or transport dependency and therefore cannot dispatch replies, supervisor messages, FATWA requests, webhooks, or provider calls.
+
+Moderation remains authoritative in Shadow Mode. A missing moderation result is `not_ready`; `block_routing` is `blocked`; and `human_review` becomes `would_wait_human`. Semantic classification is consulted only after durable `allow_routing`.
+
+The normalized shadow outcomes are:
+
+- `would_publish`: exact durable content is eligible for origin publication under the current policy;
+- `would_wait_human`: human supervision is required or still pending;
+- `would_route_fatwa`: the event belongs to the supervised FATWA path, including approved FATWA evidence when the default `telegram_only` policy still forbids an origin reply;
+- `not_ready`: required durable evidence has not yet been produced;
+- `blocked`: authoritative evidence or terminal state prevents the evaluated action.
+
+Only `would_publish` may persist `source_kind`, `evidence_id`, and `proposed_text`. SQLite enforces this invariant. The proposed text is copied exactly from an active approved FAQ entry, an accepted human supervisor response, or an externally approved FATWA result when policy permits origin publication. Other outcomes cannot carry proposed reply text.
+
+`shadow_evaluations` is unique on `(event_id, evaluator_version)`. Duplicate and racing identical evaluations converge on one immutable row. If the same event/evaluator-version key is later recomputed with different semantics, persistence raises a conflict rather than silently rewriting historical evidence. A new evaluator version is required for a new immutable observation contract.
+
+Shadow evaluation does not create or claim `outbound_actions`, does not transition inbound processing state, and does not call adapters. Aggregate reporting exposes only counts by platform, route, and outcome plus publishable/non-publishable totals; it does not expose proposed reply text.
+
 ## Reliability rules
 
 - Persist first, process later.
 - Inbound platform events are idempotent.
-- Moderation, classification, FAQ resolution, supervisor escalation, and fatwa bridge state are durable.
+- Moderation, classification, FAQ resolution, supervisor escalation, fatwa bridge state, and shadow audits are durable.
 - Duplicate/racing workers converge on one semantic durable result.
 - Outbound reply intents are persisted before external calls.
 - Concurrent publication workers cannot both claim the same pending action.
 - Provider-call uncertainty freezes the action for reconciliation instead of blind retry.
+- Shadow Mode creates no external side effect or outbound publication intent.
+- Shadow observations are immutable per event/evaluator version and conflicting recomputation fails closed.
 - SQLite foreign keys are enabled.
 - WAL mode and busy timeout are enabled where safe.
 - External failure must not silently lose accepted work.
@@ -203,3 +228,4 @@ The default FATWA publication policy is `telegram_only`, so approved fatwa text 
 - Phase 6: mock-first four-platform normalizers and injected publisher/transport clients; no live network clients.
 - Phase 7: durable supervised fatwa bridge request/result lifecycle; no legacy-bot call or modification.
 - Phase 8: exact-source crash-safe publishing dispatcher with atomic claim and uncertainty freeze; injected publishers only, no live publication.
+- Phase 9: immutable side-effect-free Shadow Mode evaluation and aggregate audit reporting; no publishers, transports, outbound actions, or processing-state mutations.

--- a/prompts/09_PHASE9_SHADOW_MODE.md
+++ b/prompts/09_PHASE9_SHADOW_MODE.md
@@ -1,0 +1,75 @@
+# Phase 9 — Shadow Mode Evaluation & Audit
+
+## Scope
+
+Implement side-effect-free evaluation over durable Gheras evidence. Shadow Mode observes what the current system would do; it does not perform the action.
+
+## Absolute constraints
+
+- No live API calls, credentials, OAuth, webhooks, polling, or production endpoints.
+- Do not call `ReplyPublisher`, supervisor transport, FATWA bridge transport, or any platform network client.
+- Do not create, claim, update, or reconcile `outbound_actions`.
+- Do not transition `inbound_events` processing state.
+- Do not generate, rewrite, summarize, translate, complete, or improve any reply text.
+- AI must never generate a fatwa.
+- Moderation remains authoritative and precedes semantic routing.
+
+## Allowed durable inputs
+
+- inbound event identity and processing metadata;
+- moderation result;
+- classification result;
+- approved FAQ resolution and exact active entry;
+- supervisor escalation and accepted human response;
+- supervised FATWA bridge request/result;
+- configured FATWA publication policy.
+
+## Outcomes
+
+- `would_publish`
+- `would_wait_human`
+- `would_route_fatwa`
+- `not_ready`
+- `blocked`
+
+Only `would_publish` may carry source kind, exact evidence id, and proposed text. That proposed text must be copied verbatim from already-authorized durable evidence.
+
+## Persistence
+
+Store one immutable `shadow_evaluations` row per `(event_id, evaluator_version)`. Duplicate/concurrent identical evaluations converge on one row. Reuse of the same key with different semantics is a conflict and fails closed.
+
+Persist normalized audit fields only. Never persist raw provider payloads, prompts, chain-of-thought, tokens, headers, or transport diagnostics.
+
+## Reporting
+
+Aggregate reports may expose counts by platform, route, and outcome plus publishable/non-publishable totals. Aggregate reports must not expose user message/reply content.
+
+## Required tests
+
+- approved active FAQ -> `would_publish` exact FAQ text;
+- revoked FAQ -> `blocked`;
+- supervisor pending -> `would_wait_human`;
+- supervisor responded -> `would_publish` exact human response;
+- FATWA pending/awaiting -> `would_route_fatwa`;
+- approved FATWA under default `telegram_only` -> no origin publication;
+- explicit origin FATWA policy -> `would_publish` exact approved external text;
+- moderation human review/block precedes classification;
+- all four V1 platforms;
+- duplicate and concurrent evaluation idempotency;
+- evaluator-version semantic conflict fails closed;
+- restart durability;
+- event processing state remains unchanged;
+- `outbound_actions` count remains unchanged;
+- aggregate report contains no proposed text.
+
+## Gates
+
+Run:
+
+```bash
+ruff check app tests
+mypy app
+pytest
+```
+
+Do not promote to `main`. Open a stacked PR against Phase 8 and perform an independent adversarial review before any promotion.

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.classification import (
+    ClassificationDecision,
+    ClassificationReason,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.fatwa import FatwaResultOutcome
+from app.domain.moderation import (
+    ModerationDecision,
+    ModerationDisposition,
+    ModerationReason,
+)
+from app.domain.publishing import FatwaPublicationPolicy, PublicationSourceKind
+from app.domain.shadow import ShadowOutcome
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.shadow_repository import ShadowConflict, ShadowRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.persistence.supervisor_repository import SupervisorRepository
+from app.services.faq import FAQService
+from app.services.fatwa import FatwaService
+from app.services.ingestion import IngestionService
+from app.services.shadow import ShadowService
+from app.services.supervisor import SupervisorService
+
+
+class Fixture:
+    def __init__(self, tmp_path: Path) -> None:
+        self.database = SQLiteDatabase(tmp_path / "router.db")
+        self.database.initialize()
+        self.events = DurableRepository(self.database)
+        self.moderation = ModerationRepository(self.database)
+        self.classifications = ClassificationRepository(self.database)
+        self.faqs = FAQRepository(self.database)
+        self.supervisors = SupervisorRepository(self.database)
+        self.fatwas = FatwaRepository(self.database)
+        self.shadows = ShadowRepository(self.database)
+
+    def ingest(
+        self,
+        *,
+        key: str,
+        platform: Platform = Platform.FACEBOOK,
+        target: str | None = "comment-1",
+    ) -> str:
+        return IngestionService(self.events).ingest_event(
+            NormalizedInboundEvent(
+                platform=platform,
+                external_event_key=key,
+                external_comment_id=target,
+                text="سؤال للاختبار",
+            )
+        ).event.id
+
+    def moderate(self, event_id: str, disposition: ModerationDisposition) -> None:
+        reason = {
+            ModerationDisposition.ALLOW_ROUTING: ModerationReason.EXPLICIT_SAFE,
+            ModerationDisposition.HUMAN_REVIEW: ModerationReason.UNCERTAIN_VERDICT,
+            ModerationDisposition.BLOCK_ROUTING: ModerationReason.EXPLICIT_UNSAFE,
+        }[disposition]
+        self.moderation.create_for_event(
+            event_id=event_id,
+            decision=ModerationDecision(disposition=disposition, reasons=(reason,)),
+            categories=(),
+            adapter_name="test-moderation",
+            adapter_version="1",
+            confidence=1.0,
+        )
+
+    def classify(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+        *,
+        faq_key: str | None = None,
+    ) -> None:
+        if route is ClassificationRoute.FAQ:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.CONFIDENT_FAQ,),
+                faq_key=faq_key or "fixture.key",
+            )
+            religious = False
+        elif route is ClassificationRoute.SUPERVISOR:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.EXPLICIT_SUPERVISOR,),
+            )
+            religious = False
+        else:
+            decision = ClassificationDecision(
+                route=route,
+                reasons=(ClassificationReason.RELIGIOUS_SAFETY_OVERRIDE,),
+            )
+            religious = True
+        self.classifications.create_for_event(
+            event_id=event_id,
+            decision=decision,
+            religious_possible=religious,
+            confidence=0.99,
+            adapter_name="test-classifier",
+            adapter_version="1",
+        )
+
+    def service(
+        self,
+        *,
+        evaluator_version: str = "shadow-v1",
+        fatwa_policy: FatwaPublicationPolicy = FatwaPublicationPolicy.TELEGRAM_ONLY,
+    ) -> ShadowService:
+        return ShadowService(
+            events=self.events,
+            moderation=self.moderation,
+            classifications=self.classifications,
+            faqs=self.faqs,
+            supervisors=self.supervisors,
+            fatwas=self.fatwas,
+            shadows=self.shadows,
+            evaluator_version=evaluator_version,
+            fatwa_policy=fatwa_policy,
+        )
+
+    def outbound_count(self) -> int:
+        with self.database.connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM outbound_actions").fetchone()
+        return int(row["count"]) if row is not None else 0
+
+
+def _prepare_faq(
+    fx: Fixture,
+    event_id: str,
+    answer: str = "الجواب التشغيلي المعتمد كما هو",
+) -> str:
+    fx.classify(event_id, ClassificationRoute.FAQ, faq_key="registration.status")
+    entry = fx.faqs.create_version(
+        faq_key="registration.status",
+        answer_text=answer,
+        source_ref="fixture://faq/registration",
+        approved_by="reviewer-1",
+        approved_at=datetime(2026, 9, 10, 8, 0, tzinfo=UTC),
+    )
+    FAQService(classifications=fx.classifications, faqs=fx.faqs).resolve(event_id)
+    return entry.id
+
+
+def _supervisor_service(fx: Fixture) -> SupervisorService:
+    return SupervisorService(
+        events=fx.events,
+        classifications=fx.classifications,
+        faqs=fx.faqs,
+        supervisors=fx.supervisors,
+    )
+
+
+def _prepare_supervisor_response(
+    fx: Fixture,
+    event_id: str,
+    answer: str = "رد المشرف المعتمد حرفيًا",
+) -> None:
+    fx.classify(event_id, ClassificationRoute.SUPERVISOR)
+    service = _supervisor_service(fx)
+    service.mark_dispatched(
+        event_id,
+        transport_name="telegram",
+        external_thread_id=f"thread-{event_id}",
+    )
+    service.accept_response(
+        event_id,
+        external_response_key=f"response-{event_id}",
+        supervisor_ref="supervisor-1",
+        text=answer,
+        received_at=datetime(2026, 9, 10, 8, 5, tzinfo=UTC),
+    )
+
+
+def _prepare_fatwa_request(fx: Fixture, event_id: str) -> FatwaService:
+    fx.classify(event_id, ClassificationRoute.FATWA)
+    service = FatwaService(
+        events=fx.events,
+        classifications=fx.classifications,
+        fatwas=fx.fatwas,
+    )
+    service.mark_dispatched(
+        event_id,
+        bridge_name="supervised-fatwa-system",
+        external_case_id=f"case-{event_id}",
+    )
+    return service
+
+
+def _approve_fatwa(
+    fx: Fixture,
+    event_id: str,
+    answer: str = "جواب شرعي معتمد من الجهة الخارجية",
+) -> None:
+    service = _prepare_fatwa_request(fx, event_id)
+    service.accept_result(
+        event_id,
+        external_result_key=f"result-{event_id}",
+        outcome=FatwaResultOutcome.APPROVED,
+        answer_text=answer,
+        approved_by="scholar-reviewer-1",
+        source_ref=f"fixture://fatwa/{event_id}",
+        received_at=datetime(2026, 9, 10, 8, 10, tzinfo=UTC),
+    )
+
+
+def test_approved_faq_would_publish_exact_text_without_outbound_action(
+    tmp_path: Path,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="faq-approved")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    answer = "النص المعتمد يبقى كما هو دون تعديل."
+    _prepare_faq(fx, event_id, answer)
+    before_state = fx.events.get_event(event_id).status
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_PUBLISH
+    assert evaluation.source_kind is PublicationSourceKind.FAQ
+    assert evaluation.proposed_text == answer
+    assert fx.outbound_count() == 0
+    assert fx.events.get_event(event_id).status is before_state
+
+
+def test_revoked_faq_is_blocked_without_publishable_text(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="faq-revoked")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_faq(fx, event_id)
+    fx.faqs.disable_active("registration.status")
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.BLOCKED
+    assert evaluation.proposed_text is None
+    assert evaluation.source_kind is None
+    assert fx.outbound_count() == 0
+
+
+def test_supervisor_pending_would_wait_human(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="supervisor-pending")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    fx.classify(event_id, ClassificationRoute.SUPERVISOR)
+    _supervisor_service(fx).ensure_escalation(event_id)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_WAIT_HUMAN
+    assert evaluation.observed_route is ClassificationRoute.SUPERVISOR
+    assert evaluation.proposed_text is None
+    assert fx.outbound_count() == 0
+
+
+def test_supervisor_response_would_publish_exact_human_text(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="supervisor-responded")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    answer = "هذا نص بشري معتمد دون إعادة صياغة."
+    _prepare_supervisor_response(fx, event_id, answer)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_PUBLISH
+    assert evaluation.source_kind is PublicationSourceKind.SUPERVISOR
+    assert evaluation.proposed_text == answer
+    assert fx.outbound_count() == 0
+
+
+def test_fatwa_awaiting_result_would_route_fatwa_without_text(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="fatwa-awaiting")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_fatwa_request(fx, event_id)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_ROUTE_FATWA
+    assert evaluation.observed_route is ClassificationRoute.FATWA
+    assert evaluation.proposed_text is None
+    assert fx.outbound_count() == 0
+
+
+def test_approved_fatwa_default_policy_never_marks_origin_publishable(
+    tmp_path: Path,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="fatwa-default")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _approve_fatwa(fx, event_id)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_ROUTE_FATWA
+    assert evaluation.proposed_text is None
+    assert evaluation.source_kind is None
+    assert fx.outbound_count() == 0
+
+
+def test_explicit_origin_fatwa_policy_uses_exact_external_approved_text(
+    tmp_path: Path,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="fatwa-origin")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    answer = "نص شرعي معتمد خارجيًا كما ورد حرفيًا."
+    _approve_fatwa(fx, event_id, answer)
+
+    evaluation = fx.service(
+        fatwa_policy=FatwaPublicationPolicy.ORIGIN_ONLY
+    ).evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_PUBLISH
+    assert evaluation.source_kind is PublicationSourceKind.FATWA
+    assert evaluation.proposed_text == answer
+    assert fx.outbound_count() == 0
+
+
+def test_moderation_human_review_precedes_existing_classification(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="moderation-human")
+    fx.moderate(event_id, ModerationDisposition.HUMAN_REVIEW)
+    fx.classify(event_id, ClassificationRoute.FAQ, faq_key="ignored.key")
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.WOULD_WAIT_HUMAN
+    assert evaluation.observed_route is None
+    assert evaluation.proposed_text is None
+
+
+def test_moderation_block_precedes_existing_classification(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="moderation-block")
+    fx.moderate(event_id, ModerationDisposition.BLOCK_ROUTING)
+    fx.classify(event_id, ClassificationRoute.FATWA)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.BLOCKED
+    assert evaluation.observed_route is None
+    assert evaluation.proposed_text is None
+
+
+def test_missing_moderation_is_not_ready_and_changes_no_event_state(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="not-ready")
+    before = fx.events.get_event(event_id)
+
+    evaluation = fx.service().evaluate(event_id)
+    after = fx.events.get_event(event_id)
+
+    assert evaluation.outcome is ShadowOutcome.NOT_READY
+    assert after.status is before.status
+    assert after.retry_count == before.retry_count
+    assert after.next_retry_at == before.next_retry_at
+    assert fx.outbound_count() == 0
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_shadow_supports_all_v1_platforms_without_external_action(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key=f"platform-{platform.value}", platform=platform)
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    answer = f"رد معتمد {platform.value}"
+    _prepare_supervisor_response(fx, event_id, answer)
+
+    evaluation = fx.service().evaluate(event_id)
+
+    assert evaluation.platform is platform
+    assert evaluation.outcome is ShadowOutcome.WOULD_PUBLISH
+    assert evaluation.proposed_text == answer
+    assert fx.outbound_count() == 0
+
+
+def test_duplicate_identical_evaluation_returns_same_durable_row(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="duplicate")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_supervisor_response(fx, event_id)
+    service = fx.service()
+
+    first = service.evaluate(event_id)
+    second = service.evaluate(event_id)
+
+    assert first.id == second.id
+    assert fx.shadows.count() == 1
+    assert fx.outbound_count() == 0
+
+
+def test_concurrent_identical_evaluations_converge_on_one_row(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="concurrent")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_supervisor_response(fx, event_id)
+
+    def evaluate() -> str:
+        return fx.service().evaluate(event_id).id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        ids = list(executor.map(lambda _: evaluate(), range(32)))
+
+    assert len(set(ids)) == 1
+    assert fx.shadows.count() == 1
+    assert fx.outbound_count() == 0
+
+
+def test_same_evaluator_version_conflicting_semantics_fail_closed(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="conflict")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_faq(fx, event_id)
+    service = fx.service(evaluator_version="shadow-conflict-v1")
+    first = service.evaluate(event_id)
+    assert first.outcome is ShadowOutcome.WOULD_PUBLISH
+
+    fx.faqs.disable_active("registration.status")
+
+    with pytest.raises(ShadowConflict):
+        service.evaluate(event_id)
+    assert fx.shadows.count() == 1
+    assert fx.outbound_count() == 0
+
+
+def test_shadow_evaluation_survives_database_restart(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+    event_id = fx.ingest(key="restart")
+    fx.moderate(event_id, ModerationDisposition.ALLOW_ROUTING)
+    _prepare_supervisor_response(fx, event_id)
+    evaluation = fx.service().evaluate(event_id)
+
+    restarted_database = SQLiteDatabase(tmp_path / "router.db")
+    restarted_database.initialize()
+    restarted_shadows = ShadowRepository(restarted_database)
+    loaded = restarted_shadows.get(event_id, "shadow-v1")
+
+    assert loaded is not None
+    assert loaded.id == evaluation.id
+    assert loaded.outcome is evaluation.outcome
+    assert loaded.proposed_text == evaluation.proposed_text
+
+
+def test_summary_exposes_counts_without_reply_content(tmp_path: Path) -> None:
+    fx = Fixture(tmp_path)
+
+    faq_event = fx.ingest(key="summary-faq")
+    fx.moderate(faq_event, ModerationDisposition.ALLOW_ROUTING)
+    secretish_answer = "نص تقييم لا يجب أن يظهر في التقرير التجميعي"
+    _prepare_faq(fx, faq_event, secretish_answer)
+    fx.service(evaluator_version="summary-v1").evaluate(faq_event)
+
+    blocked_event = fx.ingest(key="summary-blocked", platform=Platform.YOUTUBE)
+    fx.moderate(blocked_event, ModerationDisposition.BLOCK_ROUTING)
+    fx.service(evaluator_version="summary-v1").evaluate(blocked_event)
+
+    summary = fx.shadows.summary()
+
+    assert summary.total_evaluated == 2
+    assert summary.publishable == 1
+    assert summary.non_publishable == 1
+    assert summary.by_outcome[ShadowOutcome.WOULD_PUBLISH.value] == 1
+    assert summary.by_outcome[ShadowOutcome.BLOCKED.value] == 1
+    assert summary.by_platform[Platform.FACEBOOK.value] == 1
+    assert summary.by_platform[Platform.YOUTUBE.value] == 1
+    assert secretish_answer not in repr(summary)
+    assert fx.outbound_count() == 0


### PR DESCRIPTION
## Summary

Implements Issue #22 as a stacked Phase 9 change above the crash-safe Publishing Dispatcher.

### Added
- side-effect-free `ShadowService` with no publisher or transport dependency
- moderation-first evaluation; `block_routing` blocks and `human_review` waits for humans before semantic routing is considered
- normalized outcomes: `would_publish`, `would_wait_human`, `would_route_fatwa`, `not_ready`, `blocked`
- immutable `shadow_evaluations` ledger keyed by `(event_id, evaluator_version)`
- exact durable source evidence only for `would_publish`
- SQLite constraint forbidding proposed reply text on every non-publish outcome
- duplicate/concurrent evaluation convergence
- fail-closed conflict if the same event/evaluator version is recomputed with different semantics
- content-free aggregate counts by platform, route, and outcome
- restart durability and all four V1 platforms

### Side-effect proof
- Shadow Mode never creates or claims `outbound_actions`
- Shadow Mode never transitions inbound processing state
- Shadow Mode has no `ReplyPublisher`, supervisor transport, FATWA bridge transport, or network-client dependency
- approved FAQ/supervisor/FATWA text is only observed verbatim when already authorized by durable evidence and policy
- default `telegram_only` FATWA policy never marks origin publication as `would_publish`

### Validation
GitHub Actions run `34455439448` on head `e3b71cf2434a406d174d0d514070fb7440de7a51`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

### Stacked promotion gate
Targets `phase/08-publishing`, not `main`. Prior phase reviews/promotions remain prerequisites. Phase 9 requires independent adversarial review before promotion. No credentials or live integration are introduced.