### PR TITLE
Phase 10 — Final Security, Regression & Pre-Live Readiness Gate

### DIFF
--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -1,0 +1,114 @@
+# Gheras Social Router — Human Gates Before Live Activation
+
+This document lists actions that require explicit repository-owner approval. None of these actions is performed by Phase 10.
+
+## HG-01 — Legacy Facebook bot cutover
+
+**Status:** REQUIRED BEFORE LIVE
+
+The repository still contains `.github/workflows/bot.yml`, which defines `Auto Reply Workflow` with a 30-minute schedule and manual dispatch. That workflow runs the legacy root `main.py` with Facebook credentials and therefore represents a real outbound side-effect path.
+
+Available repository workflow history shows no `Auto Reply Workflow` in the newest 100 runs. An older available run exists from 2025-12-06 and failed. This evidence is not sufficient to assert that the workflow definition is disabled.
+
+Before Gheras V1 is allowed to publish live, the owner must explicitly choose and approve a cutover plan that prevents the legacy bot and the new router from replying concurrently.
+
+Possible owner-approved actions include disabling/removing the legacy workflow at cutover time, or proving that it is already disabled and cannot execute. Phase 10 does not change it.
+
+## HG-02 — Public tracked runtime-data cleanup
+
+**Status:** REQUIRED
+
+The public repository still tracks:
+
+- `log.txt`, containing historical Facebook comment identifiers, timestamps, and reply text;
+- `seen_comments.json`, a legacy runtime-state file, currently empty;
+- `bot_activity.log`, currently empty.
+
+`.gitignore` now excludes these runtime artifacts, but ignore rules do not remove files already tracked.
+
+The owner must explicitly approve removal of tracked runtime artifacts from the active code line. Any Git history rewrite is a separate, higher-impact decision and must not be performed implicitly.
+
+## HG-03 — Legacy religious-response retirement
+
+**Status:** REQUIRED BEFORE NEW ROUTER BECOMES AUTHORITATIVE
+
+The legacy `responses.json` contains keyword rules such as `(الله|يارب|جزاك)` that can produce a generic religious reply without passing through the new moderation/classification/FATWA safety boundary.
+
+The new V1 architecture does not import this legacy logic. Nevertheless, the legacy runtime must not remain an authoritative public-reply path after V1 cutover.
+
+## HG-04 — Live platform credentials and scopes
+
+**Status:** NOT PROVISIONED / NOT VERIFIED
+
+No production credentials are committed. `.env.example` contains empty placeholders only.
+
+Before live integration, the owner must explicitly provision and validate the minimum required credentials/scopes for:
+
+- Facebook / Instagram;
+- Telegram;
+- YouTube;
+- the selected moderation/classification provider, if used;
+- the supervised FATWA bridge.
+
+Credential values must remain outside Git.
+
+## HG-05 — Live platform adapter implementation
+
+**Status:** NOT IMPLEMENTED BY DESIGN
+
+Current Facebook, Instagram, Telegram, and YouTube adapters are mock-first normalization/client boundaries. Production OAuth, webhook verification, polling, token refresh, rate-limit behavior, and network clients are intentionally absent.
+
+Each live adapter requires separate implementation, provider-specific contract tests, sandbox/staging validation, and explicit approval before enabling external side effects.
+
+## HG-06 — Supervised FATWA-system integration
+
+**Status:** NOT CONNECTED BY DESIGN
+
+The Phase 7 bridge is a durable contract only. The existing FATWA system/runtime was not modified or called.
+
+The owner must approve the exact integration contract, authentication mechanism, approved-result provenance format, operational ownership, and failure/reconciliation procedure before connection.
+
+## HG-07 — FATWA publication policy
+
+**Status:** SAFE DEFAULT ACTIVE IN CODE
+
+The code default is `telegram_only`; therefore an approved FATWA result is not automatically posted to the origin comment.
+
+Changing production policy to `origin_only` or `both` requires explicit owner approval after the supervised FATWA integration has been validated.
+
+## HG-08 — Dependency/security assessment
+
+**Status:** REQUIRED BEFORE LIVE
+
+Functional CI installs dependencies from version ranges in `pyproject.toml`. Phase 10 does not claim that those resolved packages, or the legacy `requirements.txt`, are free of known vulnerabilities.
+
+Before live activation, run and record an approved software-composition/dependency vulnerability assessment and decide the production pin/lock strategy.
+
+## HG-09 — Staging Shadow Mode evaluation
+
+**Status:** REQUIRED BEFORE LIVE PUBLISHING
+
+Run the finished router against representative staging or safely replayed data in Shadow Mode. Review route/outcome aggregates and investigate unexpected `blocked`, `not_ready`, `would_wait_human`, and `would_route_fatwa` cases before permitting live publication.
+
+No production reply publishing should be enabled during this gate.
+
+## HG-10 — Production configuration and operations
+
+**Status:** REQUIRED
+
+Before production, explicitly approve:
+
+- deployment environment and database location/backup policy;
+- log retention and redaction policy;
+- operational ownership for `dispatching`/`uncertain` publication reconciliation;
+- monitoring/alerting;
+- webhook/network ingress controls where applicable;
+- rollback/cutover procedure.
+
+## HG-11 — Merge/promotion to `main`
+
+**Status:** OWNER APPROVAL REQUIRED
+
+The implementation is maintained as stacked phase branches/PRs. Phase 10 does not merge them to `main`.
+
+Promotion must occur only after prerequisite PR reviews are complete and the owner explicitly approves the merge/cutover sequence.

--- a/docs/PRE_LIVE_READINESS.md
+++ b/docs/PRE_LIVE_READINESS.md
@@ -2,11 +2,11 @@
 
 ## Verdict
 
-**MOCK-FIRST V1 ARCHITECTURE: PASS, subject to final Phase 10 CI and review.**
+**MOCK-FIRST V1 ARCHITECTURE / PRE-LIVE AUDIT: PASS.**
 
 **LIVE PRODUCTION ACTIVATION: HOLD.**
 
-The HOLD is intentional and fail-closed. It does not indicate that the durable V1 architecture has failed. It means the repository still has unresolved production/human gates that Phase 10 is not authorized to execute automatically.
+The Phase 10 machine gate and adversarial review are complete. The HOLD is intentional and fail-closed. It does not indicate that the durable V1 architecture has failed. It means the repository still has unresolved production/human gates that Phase 10 is not authorized to execute automatically.
 
 ## Audited baseline
 
@@ -26,6 +26,19 @@ The implementation stack through that baseline contains:
 8. exact-source crash-safe publication with atomic claim and `uncertain` freeze;
 9. side-effect-free immutable Shadow Mode evaluation.
 
+## Phase 10 validation evidence
+
+GitHub Actions run `34456439765` on head
+`a7d0f88bfdb5c2371a2d4e72a60952fdd737549c` completed successfully:
+
+- Ruff — PASS
+- Mypy — PASS
+- Pytest — PASS
+
+The same run showed the CI token restricted to `Contents: read` and `Metadata: read`.
+
+An adversarial comparison of `phase/09-shadow-mode` to the Phase 10 audited head found that Phase 10 changes only readiness documentation and `tests/test_pre_live_security.py`; it does not alter production service/domain/persistence logic. No new-code blocker was identified. The review also verified that static boundary tests are not being represented as a substitute for dependency SCA, provider-specific live validation, or staging evidence; those remain explicit Human Gates.
+
 ## Gate status
 
 | Gate | Status | Evidence / interpretation |
@@ -39,9 +52,10 @@ The implementation stack through that baseline contains:
 | Publication duplicate/crash safety | PASS | Durable intent before call, atomic claim, success idempotency, and `uncertain` freeze prevent blind retry. |
 | Shadow Mode side-effect isolation | PASS | No publisher/transport dependency, no outbound action creation, no processing-state mutation. |
 | Four-platform domain support | PASS | Facebook, Instagram, Telegram, and YouTube normalized behind shared contracts. |
-| New-code direct network boundary | PENDING FINAL PHASE 10 CI | Added machine-verifiable AST/source regression tests prohibiting direct network-client imports and hardcoded HTTP endpoints in the new application boundary. |
-| CI secret isolation | PENDING FINAL PHASE 10 CI | Added test requiring no production `secrets.*` consumption in CI and read-only contents permission. |
-| `.env.example` secret values | PASS / RECHECKED BY CI | Secret placeholders are present and empty. |
+| New-code direct network boundary | PASS | Phase 10 AST/source regression tests pass and prohibit common direct network-client imports plus hardcoded HTTP endpoints in the new application boundary. |
+| CI secret isolation | PASS | CI consumes no production `secrets.*`; workflow declares read-only contents permission; run evidence reports read-only contents/metadata. |
+| `.env.example` secret values | PASS | Secret placeholders are present and empty and are rechecked by CI. |
+| Independent adversarial review | PASS | Phase 10 diff changes only audit docs/tests; no implementation bypass or hidden waiver was identified. |
 | Public tracked runtime-data hygiene | **HOLD** | Public repo still tracks `log.txt` with historical Facebook identifiers/timestamps/replies, plus legacy runtime-state/log files. |
 | Legacy auto-reply cutover | **HOLD** | `.github/workflows/bot.yml` still defines a real Facebook reply workflow on a 30-minute schedule and manual dispatch. Available run history does not establish that the workflow definition is disabled. |
 | Legacy religious regex path | **HOLD** | `responses.json` still includes religious keyword auto-reply logic outside the new FATWA boundary; it must not remain authoritative after cutover. |
@@ -112,13 +126,17 @@ Required action: ensure the legacy auto-reply path is retired or otherwise unabl
 
 The new `app/` implementation is designed mock-first. Platform modules normalize identifiers/text and delegate future I/O through injected client protocols. Production network clients are intentionally absent.
 
-Phase 10 adds regression tests that fail if new core/platform-boundary Python modules directly import common live-network/vendor clients or if the new application introduces hardcoded `http://` / `https://` endpoints.
+Phase 10 regression tests fail if new core/platform-boundary Python modules directly import common live-network/vendor clients or if the new application introduces hardcoded `http://` / `https://` endpoints.
 
-Legacy root code is intentionally excluded from that PASS claim and is documented separately as a cutover HOLD.
+These tests are guardrails, not proof that future live integrations are secure. Provider-specific clients, OAuth/webhook logic, scopes, rate limits, retry semantics, TLS/network controls, and staging behavior remain outside the current PASS and require their own live-integration gates.
+
+Legacy root code is intentionally excluded from the new-code PASS claim and is documented separately as a cutover HOLD.
 
 ## Dependency/configuration findings
 
 New project metadata currently declares Python `>=3.12`, FastAPI and Uvicorn runtime ranges, and HTTPX/Mypy/Pytest/Ruff development ranges. CI runs on Python 3.12 and installs the project from these ranges.
+
+The successful Phase 10 CI run resolved Python 3.12.14 on the hosted runner. GitHub Actions emitted a deprecation warning that `actions/checkout@v4` and `actions/setup-python@v5` target the older Node runtime and are currently being forced onto Node 24. This did not fail CI, but action-version maintenance should be included in pre-production toolchain hardening when compatible maintained releases are selected and verified.
 
 Legacy `requirements.txt` separately contains unpinned `requests`, unpinned `python-dotenv`, and `mysql-connector-python==8.1.0`.
 
@@ -151,12 +169,14 @@ Phase 10 does not:
 - merge any phase PR to `main`;
 - assert production readiness while any mandatory Human Gate remains open.
 
-## Final Phase 10 closure rule
+## Final Phase 10 closure
 
-Phase 10 may be marked **PASS AS A PRE-LIVE AUDIT/HARDENING PHASE** when:
+The Phase 10 audit/hardening closure conditions have been met:
 
-1. the Phase 10 security-regression tests pass Ruff/Mypy/Pytest on the final documentation head;
-2. independent adversarial review finds no new-code blocker;
-3. all unresolved live concerns remain explicitly recorded as HOLD/Human Gates rather than being silently waived.
+1. Phase 10 security-regression tests passed Ruff/Mypy/Pytest;
+2. adversarial review found no new-code blocker or hidden waiver;
+3. unresolved live concerns remain explicitly recorded as HOLD/Human Gates.
 
-Even after that audit PASS, **LIVE PRODUCTION ACTIVATION remains HOLD until the Human Gates are explicitly closed.**
+Therefore **Phase 10 is PASS as a pre-live audit/hardening phase**.
+
+**LIVE PRODUCTION ACTIVATION remains HOLD until the Human Gates are explicitly closed.**

--- a/docs/PRE_LIVE_READINESS.md
+++ b/docs/PRE_LIVE_READINESS.md
@@ -1,0 +1,162 @@
+# Gheras Social Router — Phase 10 Pre-Live Readiness
+
+## Verdict
+
+**MOCK-FIRST V1 ARCHITECTURE: PASS, subject to final Phase 10 CI and review.**
+
+**LIVE PRODUCTION ACTIVATION: HOLD.**
+
+The HOLD is intentional and fail-closed. It does not indicate that the durable V1 architecture has failed. It means the repository still has unresolved production/human gates that Phase 10 is not authorized to execute automatically.
+
+## Audited baseline
+
+Phase 10 was branched from the Phase 9 green head:
+
+`e3b71cf2434a406d174d0d514070fb7440de7a51`
+
+The implementation stack through that baseline contains:
+
+1. durable persist-first event processing and inbound/outbound idempotency;
+2. moderation before classification;
+3. structured routing-only classification with religious safety override;
+4. versioned approved FAQ answers;
+5. durable supervisor escalation and accepted human response;
+6. mock-first adapters for Facebook, Instagram, Telegram, and YouTube;
+7. durable supervised FATWA bridge contract;
+8. exact-source crash-safe publication with atomic claim and `uncertain` freeze;
+9. side-effect-free immutable Shadow Mode evaluation.
+
+## Gate status
+
+| Gate | Status | Evidence / interpretation |
+| --- | --- | --- |
+| Persist-first/idempotency architecture | PASS | Durable SQLite state, unique inbound/outbound boundaries, restart/concurrency tests from earlier phases. |
+| Moderation precedes semantic routing | PASS | Classification eligibility and Shadow Mode both require authoritative moderation evidence. |
+| AI-generated FATWA prevention | PASS | Classifier is routing-only; FATWA answer text can originate only from an externally approved bridge result. |
+| Approved FAQ only | PASS | Publication requires an exact durable FAQ resolution and the referenced entry must still be active. |
+| Supervisor answer provenance | PASS | Publication requires the single durable accepted human response. |
+| FATWA answer provenance | PASS | Publication requires `approved_result` plus externally supplied answer/provenance fields. |
+| Publication duplicate/crash safety | PASS | Durable intent before call, atomic claim, success idempotency, and `uncertain` freeze prevent blind retry. |
+| Shadow Mode side-effect isolation | PASS | No publisher/transport dependency, no outbound action creation, no processing-state mutation. |
+| Four-platform domain support | PASS | Facebook, Instagram, Telegram, and YouTube normalized behind shared contracts. |
+| New-code direct network boundary | PENDING FINAL PHASE 10 CI | Added machine-verifiable AST/source regression tests prohibiting direct network-client imports and hardcoded HTTP endpoints in the new application boundary. |
+| CI secret isolation | PENDING FINAL PHASE 10 CI | Added test requiring no production `secrets.*` consumption in CI and read-only contents permission. |
+| `.env.example` secret values | PASS / RECHECKED BY CI | Secret placeholders are present and empty. |
+| Public tracked runtime-data hygiene | **HOLD** | Public repo still tracks `log.txt` with historical Facebook identifiers/timestamps/replies, plus legacy runtime-state/log files. |
+| Legacy auto-reply cutover | **HOLD** | `.github/workflows/bot.yml` still defines a real Facebook reply workflow on a 30-minute schedule and manual dispatch. Available run history does not establish that the workflow definition is disabled. |
+| Legacy religious regex path | **HOLD** | `responses.json` still includes religious keyword auto-reply logic outside the new FATWA boundary; it must not remain authoritative after cutover. |
+| Live provider adapters | **HOLD** | Production OAuth/webhook/network implementations intentionally do not exist yet. |
+| Supervised FATWA live connection | **HOLD** | Contract exists; real external system connection intentionally not enabled. |
+| Dependency vulnerability/SCA assessment | **HOLD** | Functional dependency installation is tested; no claim of vulnerability-free resolved packages is made. |
+| Staging Shadow Mode evaluation | **HOLD** | Code is ready for shadow evaluation, but representative staging/replay evidence has not yet been collected. |
+| Production observability/backup/reconciliation runbook | **HOLD** | Requires deployment-specific owner decisions. |
+| Merge/promotion to `main` | **HOLD / HUMAN GATE** | Stacked PRs have not been merged to `main`. |
+
+## Repository/data-hygiene findings
+
+### Finding DH-01 — tracked `log.txt`
+
+Severity for live readiness: **BLOCKER / HOLD**
+
+The repository is public and currently tracks `log.txt`. The file contains historical Facebook comment identifiers, timestamps, and reply text. `.gitignore` now lists `log.txt` and `*.log`, but ignore configuration does not remove already tracked files.
+
+Required action: explicit owner-approved tracked-file cleanup before live promotion. Whether to rewrite historical Git objects is a separate decision because it changes published history and should not be done implicitly.
+
+### Finding DH-02 — legacy state/log artifacts remain tracked
+
+Severity: **HOLD / CLEANUP REQUIRED**
+
+`seen_comments.json` and `bot_activity.log` remain tracked even though `.gitignore` excludes them. They are currently empty on the audited branch, but runtime state should not be version-controlled in the production code line.
+
+### Finding DH-03 — secret placeholders
+
+Status: **PASS**
+
+`.env.example` has empty values for OpenAI, Meta, Telegram, and FATWA bridge secrets. New application settings read secrets from process environment variables and hide secret fields from dataclass representation.
+
+No production secret value was identified in the audited `.env.example` or new `app/config.py`.
+
+## Legacy workflow findings
+
+### Finding WF-01 — real side-effect workflow remains defined
+
+Severity: **BLOCKER FOR CUTOVER**
+
+`.github/workflows/bot.yml`:
+
+- has a `*/30 * * * *` schedule plus `workflow_dispatch`;
+- loads `FB_ACCESS_TOKEN` and `FB_PAGE_ID` from GitHub secrets;
+- runs root `python main.py`;
+- root `bot_manager.py` performs real Graph API GET and POST calls;
+- uploads `bot_activity.log` and `log.txt` as workflow artifacts.
+
+The available repository run history has 105 runs. `Auto Reply Workflow` does not appear in the newest 100-run page. An older available run dated 2025-12-06 exists and failed. Therefore there is no evidence of a recent legacy run in the available history, but this audit does **not** assert that the workflow definition is disabled.
+
+### Finding WF-02 — legacy dedupe is not durable across clean runners
+
+Severity: **CUTOVER RISK**
+
+The legacy root bot uses `seen_comments.json` as its dedupe state. The workflow checks out the repository and runs the bot but does not commit or otherwise persist the updated `seen_comments.json` back to durable shared state. GitHub-hosted runners are ephemeral. The historical `log.txt` contains repeated comment identifiers across different executions, consistent with duplicate-reply risk.
+
+This observation is about the legacy implementation only. The new V1 uses durable database idempotency instead.
+
+### Finding WF-03 — legacy religious keyword replies bypass new routing
+
+Severity: **BLOCKER FOR DUAL-AUTHORITY OPERATION**
+
+Legacy `responses.json` contains `(الله|يارب|جزاك)` mapped to a generic reply. If the legacy bot remains able to publish while Gheras V1 becomes authoritative, religious comments could bypass the new moderation/classification/FATWA design.
+
+Required action: ensure the legacy auto-reply path is retired or otherwise unable to compete with the new router at cutover.
+
+## Network-boundary findings
+
+The new `app/` implementation is designed mock-first. Platform modules normalize identifiers/text and delegate future I/O through injected client protocols. Production network clients are intentionally absent.
+
+Phase 10 adds regression tests that fail if new core/platform-boundary Python modules directly import common live-network/vendor clients or if the new application introduces hardcoded `http://` / `https://` endpoints.
+
+Legacy root code is intentionally excluded from that PASS claim and is documented separately as a cutover HOLD.
+
+## Dependency/configuration findings
+
+New project metadata currently declares Python `>=3.12`, FastAPI and Uvicorn runtime ranges, and HTTPX/Mypy/Pytest/Ruff development ranges. CI runs on Python 3.12 and installs the project from these ranges.
+
+Legacy `requirements.txt` separately contains unpinned `requests`, unpinned `python-dotenv`, and `mysql-connector-python==8.1.0`.
+
+Phase 10 makes **no vulnerability-free claim** for either dependency set. A current software-composition analysis and a production lock/pinning decision are mandatory Human Gates before live deployment.
+
+## Production blockers / Human Gates
+
+The authoritative list is `docs/HUMAN_GATES.md`. The major blockers are:
+
+- owner-approved legacy workflow cutover;
+- removal/handling of tracked public runtime data;
+- retirement of legacy religious regex auto-replies as an authoritative path;
+- production credential/scopes provisioning outside Git;
+- implementation and staging verification of live Facebook/Instagram/Telegram/YouTube adapters;
+- approved live supervised-FATWA integration contract;
+- dependency/SCA assessment and production lock strategy;
+- representative Shadow Mode staging/replay evaluation;
+- production database, backup, monitoring, reconciliation, and rollback decisions;
+- explicit merge/promotion approval.
+
+## What Phase 10 does not authorize
+
+Phase 10 does not:
+
+- delete tracked legacy files or rewrite Git history;
+- disable `.github/workflows/bot.yml`;
+- rotate/provision secrets;
+- call Facebook, Instagram, Telegram, YouTube, an AI provider, or the existing FATWA bot;
+- publish a reply;
+- merge any phase PR to `main`;
+- assert production readiness while any mandatory Human Gate remains open.
+
+## Final Phase 10 closure rule
+
+Phase 10 may be marked **PASS AS A PRE-LIVE AUDIT/HARDENING PHASE** when:
+
+1. the Phase 10 security-regression tests pass Ruff/Mypy/Pytest on the final documentation head;
+2. independent adversarial review finds no new-code blocker;
+3. all unresolved live concerns remain explicitly recorded as HOLD/Human Gates rather than being silently waived.
+
+Even after that audit PASS, **LIVE PRODUCTION ACTIVATION remains HOLD until the Human Gates are explicitly closed.**

--- a/tests/test_pre_live_security.py
+++ b/tests/test_pre_live_security.py
@@ -35,6 +35,10 @@ def _python_files() -> list[Path]:
     return sorted(path for root in CORE_ROOTS for path in root.rglob("*.py"))
 
 
+def _case_id(value: Path) -> str:
+    return str(value.relative_to(PROJECT_ROOT))
+
+
 def _import_roots(path: Path) -> set[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     roots: set[str] = set()
@@ -46,7 +50,7 @@ def _import_roots(path: Path) -> set[str]:
     return roots
 
 
-@pytest.mark.parametrize("path", _python_files(), ids=lambda value: str(value.relative_to(PROJECT_ROOT)))
+@pytest.mark.parametrize("path", _python_files(), ids=_case_id)
 def test_new_core_has_no_direct_network_client_imports(path: Path) -> None:
     imported = _import_roots(path)
     assert imported.isdisjoint(FORBIDDEN_NETWORK_IMPORT_ROOTS), (
@@ -55,7 +59,7 @@ def test_new_core_has_no_direct_network_client_imports(path: Path) -> None:
     )
 
 
-@pytest.mark.parametrize("path", _python_files(), ids=lambda value: str(value.relative_to(PROJECT_ROOT)))
+@pytest.mark.parametrize("path", _python_files(), ids=_case_id)
 def test_new_core_does_not_import_legacy_bot_modules(path: Path) -> None:
     imported = _import_roots(path)
     assert imported.isdisjoint(LEGACY_IMPORT_ROOTS), (

--- a/tests/test_pre_live_security.py
+++ b/tests/test_pre_live_security.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = PROJECT_ROOT / "app"
+CORE_ROOTS = (
+    APP_ROOT / "domain",
+    APP_ROOT / "services",
+    APP_ROOT / "persistence",
+    APP_ROOT / "adapters" / "platforms",
+)
+
+FORBIDDEN_NETWORK_IMPORT_ROOTS = {
+    "aiohttp",
+    "aiogram",
+    "facebook_business",
+    "googleapiclient",
+    "httpx",
+    "requests",
+    "telegram",
+    "urllib3",
+}
+LEGACY_IMPORT_ROOTS = {
+    "bot_manager",
+    "database_config",
+    "database_manager",
+}
+
+
+def _python_files() -> list[Path]:
+    return sorted(path for root in CORE_ROOTS for path in root.rglob("*.py"))
+
+
+def _import_roots(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+@pytest.mark.parametrize("path", _python_files(), ids=lambda value: str(value.relative_to(PROJECT_ROOT)))
+def test_new_core_has_no_direct_network_client_imports(path: Path) -> None:
+    imported = _import_roots(path)
+    assert imported.isdisjoint(FORBIDDEN_NETWORK_IMPORT_ROOTS), (
+        f"{path.relative_to(PROJECT_ROOT)} imports a forbidden live-network dependency: "
+        f"{sorted(imported & FORBIDDEN_NETWORK_IMPORT_ROOTS)}"
+    )
+
+
+@pytest.mark.parametrize("path", _python_files(), ids=lambda value: str(value.relative_to(PROJECT_ROOT)))
+def test_new_core_does_not_import_legacy_bot_modules(path: Path) -> None:
+    imported = _import_roots(path)
+    assert imported.isdisjoint(LEGACY_IMPORT_ROOTS), (
+        f"{path.relative_to(PROJECT_ROOT)} imports legacy runtime code: "
+        f"{sorted(imported & LEGACY_IMPORT_ROOTS)}"
+    )
+
+
+def test_new_application_contains_no_hardcoded_http_endpoints() -> None:
+    offenders: list[str] = []
+    for path in sorted(APP_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "http://" in text or "https://" in text:
+            offenders.append(str(path.relative_to(PROJECT_ROOT)))
+    assert offenders == []
+
+
+def test_ci_workflow_does_not_consume_production_secrets() -> None:
+    ci = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "secrets." not in ci
+    assert "contents: read" in ci
+
+
+def test_secret_values_are_empty_in_env_example() -> None:
+    env_lines = (PROJECT_ROOT / ".env.example").read_text(encoding="utf-8").splitlines()
+    values = {
+        key: value
+        for line in env_lines
+        if line and not line.startswith("#") and "=" in line
+        for key, value in [line.split("=", 1)]
+    }
+    secret_keys = {
+        "OPENAI_API_KEY",
+        "META_ACCESS_TOKEN",
+        "META_APP_SECRET",
+        "META_VERIFY_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+        "FATWA_BRIDGE_SECRET",
+    }
+    assert secret_keys.issubset(values)
+    assert all(values[key] == "" for key in secret_keys)
+
+
+def test_shadow_service_has_no_external_action_contract_imports() -> None:
+    path = APP_ROOT / "services" / "shadow.py"
+    text = path.read_text(encoding="utf-8")
+    forbidden_symbols = {
+        "ReplyPublisher",
+        "SupervisorTransportAdapter",
+        "FatwaBridgeAdapter",
+        "PublishingRepository",
+    }
+    assert all(symbol not in text for symbol in forbidden_symbols)


### PR DESCRIPTION
## Summary

Closes the Phase 10 audit/hardening scope from Issue #24 as a stacked change above Phase 9.

### Phase 10 result
- **Mock-first V1 architecture / pre-live audit: PASS**
- **Live production activation: HOLD**

The HOLD is intentional and fail-closed. Phase 10 does not provision credentials, enable live adapters, disable the legacy bot, delete tracked legacy evidence, rewrite Git history, publish replies, or merge to `main`.

### Added
- `docs/PRE_LIVE_READINESS.md` with explicit PASS/HOLD evidence per gate
- `docs/HUMAN_GATES.md` with owner-approved actions required before production
- `tests/test_pre_live_security.py` with machine-verifiable guardrails for:
  - no direct common live-network client imports in the new core/platform boundary
  - no import of legacy runtime modules into the new application
  - no hardcoded HTTP endpoints in `app/`
  - no production `secrets.*` usage in CI and read-only contents permission
  - empty secret placeholders in `.env.example`
  - Shadow Mode isolation from external action contracts

### Key HOLD findings preserved
- public tracked `log.txt` contains historical Facebook identifiers/timestamps/replies
- `seen_comments.json` and `bot_activity.log` remain tracked legacy runtime artifacts
- legacy `.github/workflows/bot.yml` still defines a real Facebook reply path with 30-minute schedule/manual dispatch; available history does not prove the workflow definition is disabled
- legacy `responses.json` includes religious keyword auto-reply logic outside the new FATWA boundary
- live Facebook/Instagram/Telegram/YouTube adapters are not implemented by design
- supervised FATWA live connection, SCA/dependency locking, staging Shadow Mode evidence, production operations/runbook, and cutover remain Human Gates

### Validation
Final GitHub Actions run `34457535071` on head `287a97cd9f2a83bf524b8380f425bd0a0382c5fb`:
- Ruff — PASS
- Mypy — PASS
- Pytest — PASS

An adversarial comparison against `phase/09-shadow-mode` confirms Phase 10 changes only readiness documentation and security regression tests; no production service/domain/persistence implementation is changed.

### Promotion boundary
Targets `phase/09-shadow-mode`, not `main`. No production activation is authorized by this PR.