### PR TITLE
Phase 12 — Sandbox-Capable Live Clients, Disabled by Default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DATABASE_URL=sqlite:///./data/gheras_router.db
 OPENAI_API_KEY=
 
 # Meta / Facebook / Instagram
+META_GRAPH_API_VERSION=
 META_PAGE_ID=
 INSTAGRAM_BUSINESS_ACCOUNT_ID=
 META_ACCESS_TOKEN=

--- a/app/adapters/platforms/live_security.py
+++ b/app/adapters/platforms/live_security.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -22,6 +23,19 @@ class YouTubeIngestionMode(StrEnum):
     """Supported YouTube comment-ingestion mechanism for the prepared adapter."""
 
     POLL_COMMENT_THREADS = "poll_comment_threads"
+
+
+_META_VERSION_PATTERN = re.compile(r"^v[1-9][0-9]*\.[0-9]+$")
+
+
+def validate_meta_graph_api_version(value: str) -> str:
+    """Accept only a compact Meta Graph API version such as ``v26.0``."""
+
+    if not isinstance(value, str) or not _META_VERSION_PATTERN.fullmatch(value):
+        raise WebhookVerificationError("invalid Meta Graph API version")
+    if len(value) > 16:
+        raise WebhookVerificationError("Meta Graph API version is too long")
+    return value
 
 
 def _required_secret(value: str, *, field: str) -> str:

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,7 @@ class Settings:
     log_level: str = "INFO"
     database_url: str = "sqlite:///./data/gheras_router.db"
 
+    meta_graph_api_version: str | None = None
     meta_page_id: str | None = None
     instagram_business_account_id: str | None = None
     telegram_supervisor_chat_id: str | None = None
@@ -56,6 +57,7 @@ class Settings:
             environment=_environment_name(getenv("APP_ENV")),
             log_level=getenv("LOG_LEVEL", "INFO").upper(),
             database_url=getenv("DATABASE_URL", "sqlite:///./data/gheras_router.db"),
+            meta_graph_api_version=getenv("META_GRAPH_API_VERSION"),
             meta_page_id=getenv("META_PAGE_ID"),
             instagram_business_account_id=getenv("INSTAGRAM_BUSINESS_ACCOUNT_ID"),
             telegram_supervisor_chat_id=getenv("TELEGRAM_SUPERVISOR_CHAT_ID"),

--- a/app/integrations/__init__.py
+++ b/app/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""External integration implementations isolated from the provider-neutral core."""

--- a/app/integrations/live/__init__.py
+++ b/app/integrations/live/__init__.py
@@ -1,0 +1,1 @@
+"""Sandbox-capable provider clients. No production execution permit exists in Phase 12."""

--- a/app/integrations/live/activation.py
+++ b/app/integrations/live/activation.py
@@ -1,0 +1,47 @@
+"""Explicit execution capability for sandbox provider calls.
+
+Environment variables cannot create this capability. Phase 12 intentionally has
+no production-mode permit or automatic permit factory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class ExternalIntegrationDisabled(RuntimeError):
+    """Raised when provider execution is attempted without an explicit permit."""
+
+
+_PERMIT_MARKER = object()
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class SandboxExecutionPermit:
+    """Opaque capability proving that a caller explicitly entered sandbox validation."""
+
+    purpose: str
+    _marker: object
+
+    def __init__(self, purpose: str, marker: object) -> None:
+        if marker is not _PERMIT_MARKER:
+            raise ExternalIntegrationDisabled("invalid sandbox execution permit")
+        normalized = purpose.strip()
+        if normalized != "sandbox_validation":
+            raise ExternalIntegrationDisabled("unsupported external execution purpose")
+        object.__setattr__(self, "purpose", normalized)
+        object.__setattr__(self, "_marker", marker)
+
+
+def issue_sandbox_execution_permit(*, purpose: str) -> SandboxExecutionPermit:
+    """Issue a sandbox-only capability after an explicit code-level action."""
+
+    return SandboxExecutionPermit(purpose, _PERMIT_MARKER)
+
+
+def require_sandbox_execution(permit: SandboxExecutionPermit | None) -> SandboxExecutionPermit:
+    """Fail before request construction when the explicit capability is absent."""
+
+    if permit is None or permit._marker is not _PERMIT_MARKER:
+        raise ExternalIntegrationDisabled("sandbox execution permit is required")
+    return permit

--- a/app/integrations/live/base.py
+++ b/app/integrations/live/base.py
@@ -1,0 +1,164 @@
+"""Shared sandbox HTTP boundary with strict host and error redaction rules."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from app.integrations.live.activation import SandboxExecutionPermit, require_sandbox_execution
+
+APPROVED_PROVIDER_HOSTS = frozenset(
+    {
+        "api.telegram.org",
+        "graph.facebook.com",
+        "www.googleapis.com",
+    }
+)
+
+
+class ProviderIntegrationError(RuntimeError):
+    """Base provider error that deliberately excludes URL/body/credential data."""
+
+
+class ProviderTransportError(ProviderIntegrationError):
+    def __init__(self, *, provider: str, operation: str) -> None:
+        self.provider = provider
+        self.operation = operation
+        super().__init__(f"{provider} transport failure during {operation}")
+
+
+class ProviderHTTPError(ProviderIntegrationError):
+    def __init__(
+        self,
+        *,
+        provider: str,
+        operation: str,
+        status_code: int,
+        retryable: bool,
+    ) -> None:
+        self.provider = provider
+        self.operation = operation
+        self.status_code = status_code
+        self.retryable = retryable
+        super().__init__(
+            f"{provider} HTTP {status_code} during {operation}; retryable={retryable}"
+        )
+
+
+class ProviderProtocolError(ProviderIntegrationError):
+    def __init__(self, *, provider: str, operation: str, reason: str) -> None:
+        self.provider = provider
+        self.operation = operation
+        self.reason = reason
+        super().__init__(f"{provider} protocol failure during {operation}: {reason}")
+
+
+def ensure_approved_url(url: str) -> httpx.URL:
+    """Require HTTPS and one exact allowlisted provider hostname."""
+
+    parsed = httpx.URL(url)
+    if parsed.scheme != "https":
+        raise ProviderProtocolError(
+            provider="boundary",
+            operation="validate_url",
+            reason="HTTPS is required",
+        )
+    if parsed.host not in APPROVED_PROVIDER_HOSTS:
+        raise ProviderProtocolError(
+            provider="boundary",
+            operation="validate_url",
+            reason="provider host is not allowlisted",
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise ProviderProtocolError(
+            provider="boundary",
+            operation="validate_url",
+            reason="userinfo in provider URL is forbidden",
+        )
+    return parsed
+
+
+def _retryable_status(status_code: int) -> bool:
+    return status_code == 429 or 500 <= status_code <= 599
+
+
+async def request_json(
+    *,
+    http: httpx.AsyncClient,
+    permit: SandboxExecutionPermit | None,
+    provider: str,
+    operation: str,
+    method: str,
+    url: str,
+    headers: Mapping[str, str] | None = None,
+    params: Mapping[str, str | int] | None = None,
+    data: Mapping[str, str] | None = None,
+    json_body: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Execute one explicitly permitted request and return a JSON object only."""
+
+    require_sandbox_execution(permit)
+    approved_url = ensure_approved_url(url)
+    request = http.build_request(
+        method,
+        approved_url,
+        headers=headers,
+        params=params,
+        data=data,
+        json=json_body,
+    )
+    try:
+        response = await http.send(request)
+    except httpx.HTTPError:
+        raise ProviderTransportError(provider=provider, operation=operation) from None
+
+    if response.status_code >= 400:
+        raise ProviderHTTPError(
+            provider=provider,
+            operation=operation,
+            status_code=response.status_code,
+            retryable=_retryable_status(response.status_code),
+        )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        raise ProviderProtocolError(
+            provider=provider,
+            operation=operation,
+            reason="response is not valid JSON",
+        ) from None
+    if not isinstance(payload, dict):
+        raise ProviderProtocolError(
+            provider=provider,
+            operation=operation,
+            reason="response JSON must be an object",
+        )
+    return payload
+
+
+def required_response_id(
+    payload: Mapping[str, Any],
+    *,
+    provider: str,
+    operation: str,
+    field: str = "id",
+) -> str:
+    """Extract a stable provider id without including payload data in errors."""
+
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip() or any(char.isspace() for char in value):
+        raise ProviderProtocolError(
+            provider=provider,
+            operation=operation,
+            reason=f"missing or invalid {field}",
+        )
+    if len(value) > 512:
+        raise ProviderProtocolError(
+            provider=provider,
+            operation=operation,
+            reason=f"{field} exceeds maximum length",
+        )
+    return value

--- a/app/integrations/live/base.py
+++ b/app/integrations/live/base.py
@@ -16,6 +16,7 @@ APPROVED_PROVIDER_HOSTS = frozenset(
         "www.googleapis.com",
     }
 )
+_MAX_RESPONSE_BYTES = 1_000_000
 
 
 class ProviderIntegrationError(RuntimeError):
@@ -71,11 +72,23 @@ def ensure_approved_url(url: str) -> httpx.URL:
             operation="validate_url",
             reason="provider host is not allowlisted",
         )
+    if parsed.port is not None:
+        raise ProviderProtocolError(
+            provider="boundary",
+            operation="validate_url",
+            reason="non-default provider port is forbidden",
+        )
     if parsed.userinfo:
         raise ProviderProtocolError(
             provider="boundary",
             operation="validate_url",
             reason="userinfo in provider URL is forbidden",
+        )
+    if parsed.fragment:
+        raise ProviderProtocolError(
+            provider="boundary",
+            operation="validate_url",
+            reason="provider URL fragment is forbidden",
         )
     return parsed
 
@@ -97,7 +110,7 @@ async def request_json(
     data: Mapping[str, str] | None = None,
     json_body: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any]:
-    """Execute one explicitly permitted request and return a JSON object only."""
+    """Execute one explicitly permitted request and return a bounded JSON object."""
 
     require_sandbox_execution(permit)
     approved_url = ensure_approved_url(url)
@@ -110,7 +123,7 @@ async def request_json(
         json=json_body,
     )
     try:
-        response = await http.send(request)
+        response = await http.send(request, follow_redirects=False)
     except httpx.HTTPError:
         raise ProviderTransportError(provider=provider, operation=operation) from None
 
@@ -120,6 +133,12 @@ async def request_json(
             operation=operation,
             status_code=response.status_code,
             retryable=_retryable_status(response.status_code),
+        )
+    if len(response.content) > _MAX_RESPONSE_BYTES:
+        raise ProviderProtocolError(
+            provider=provider,
+            operation=operation,
+            reason="response exceeds maximum size",
         )
 
     try:

--- a/app/integrations/live/base.py
+++ b/app/integrations/live/base.py
@@ -71,7 +71,7 @@ def ensure_approved_url(url: str) -> httpx.URL:
             operation="validate_url",
             reason="provider host is not allowlisted",
         )
-    if parsed.username is not None or parsed.password is not None:
+    if parsed.userinfo:
         raise ProviderProtocolError(
             provider="boundary",
             operation="validate_url",

--- a/app/integrations/live/meta.py
+++ b/app/integrations/live/meta.py
@@ -7,6 +7,8 @@ from urllib.parse import quote
 import httpx
 
 from app.adapters.platforms.common import reply_text, required_id
+from app.adapters.platforms.facebook import FacebookReplyClient
+from app.adapters.platforms.instagram import InstagramReplyClient
 from app.adapters.platforms.live_security import validate_meta_graph_api_version
 from app.integrations.live.activation import SandboxExecutionPermit
 from app.integrations.live.base import ProviderProtocolError, request_json, required_response_id
@@ -30,8 +32,8 @@ def _credential(value: str, *, field: str) -> str:
     return value
 
 
-class FacebookGraphReplyClient:
-    """Implements the FacebookReplyClient protocol through an injected HTTP client."""
+class FacebookGraphReplyClient(FacebookReplyClient):
+    """FacebookReplyClient implementation through an injected HTTP client."""
 
     def __init__(
         self,
@@ -66,8 +68,8 @@ class FacebookGraphReplyClient:
         )
 
 
-class InstagramGraphReplyClient:
-    """Implements the Instagram reply-client protocol for Facebook Login mode."""
+class InstagramGraphReplyClient(InstagramReplyClient):
+    """InstagramReplyClient implementation for Facebook Login mode."""
 
     def __init__(
         self,

--- a/app/integrations/live/meta.py
+++ b/app/integrations/live/meta.py
@@ -1,0 +1,102 @@
+"""Sandbox-capable Facebook and Instagram Graph API reply clients."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import httpx
+
+from app.adapters.platforms.common import reply_text, required_id
+from app.adapters.platforms.live_security import validate_meta_graph_api_version
+from app.integrations.live.activation import SandboxExecutionPermit
+from app.integrations.live.base import ProviderProtocolError, request_json, required_response_id
+
+_META_GRAPH_BASE = "https://graph.facebook.com"
+
+
+def _credential(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ProviderProtocolError(
+            provider="meta",
+            operation="configure",
+            reason=f"missing or invalid {field}",
+        )
+    if len(value) > 8192:
+        raise ProviderProtocolError(
+            provider="meta",
+            operation="configure",
+            reason=f"{field} exceeds maximum length",
+        )
+    return value
+
+
+class FacebookGraphReplyClient:
+    """Implements the FacebookReplyClient protocol through an injected HTTP client."""
+
+    def __init__(
+        self,
+        *,
+        http: httpx.AsyncClient,
+        permit: SandboxExecutionPermit | None,
+        access_token: str,
+        api_version: str,
+    ) -> None:
+        self._http = http
+        self._permit = permit
+        self._access_token = _credential(access_token, field="access_token")
+        self._api_version = validate_meta_graph_api_version(api_version)
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        comment = quote(required_id(comment_id, field="comment_id"), safe="")
+        url = f"{_META_GRAPH_BASE}/{self._api_version}/{comment}/comments"
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="facebook",
+            operation="reply_to_comment",
+            method="POST",
+            url=url,
+            headers={"Authorization": f"Bearer {self._access_token}"},
+            data={"message": reply_text(text)},
+        )
+        return required_response_id(
+            payload,
+            provider="facebook",
+            operation="reply_to_comment",
+        )
+
+
+class InstagramGraphReplyClient:
+    """Implements the Instagram reply-client protocol for Facebook Login mode."""
+
+    def __init__(
+        self,
+        *,
+        http: httpx.AsyncClient,
+        permit: SandboxExecutionPermit | None,
+        access_token: str,
+        api_version: str,
+    ) -> None:
+        self._http = http
+        self._permit = permit
+        self._access_token = _credential(access_token, field="access_token")
+        self._api_version = validate_meta_graph_api_version(api_version)
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        comment = quote(required_id(comment_id, field="comment_id"), safe="")
+        url = f"{_META_GRAPH_BASE}/{self._api_version}/{comment}/replies"
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="instagram",
+            operation="reply_to_comment",
+            method="POST",
+            url=url,
+            headers={"Authorization": f"Bearer {self._access_token}"},
+            data={"message": reply_text(text)},
+        )
+        return required_response_id(
+            payload,
+            provider="instagram",
+            operation="reply_to_comment",
+        )

--- a/app/integrations/live/telegram.py
+++ b/app/integrations/live/telegram.py
@@ -1,0 +1,138 @@
+"""Sandbox-capable Telegram Bot API transport client."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from app.adapters.platforms.common import reply_text, required_id, required_text
+from app.integrations.live.activation import SandboxExecutionPermit
+from app.integrations.live.base import ProviderProtocolError, request_json
+
+_TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+def _bot_token(value: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation="configure",
+            reason="missing or invalid bot token",
+        )
+    if len(value) > 8192:
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation="configure",
+            reason="bot token exceeds maximum length",
+        )
+    return value
+
+
+def _message_id(payload: Mapping[str, Any], *, operation: str) -> str:
+    if payload.get("ok") is not True:
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation=operation,
+            reason="response did not report success",
+        )
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation=operation,
+            reason="response result is missing",
+        )
+    value = result.get("message_id")
+    if isinstance(value, int) and value > 0:
+        return str(value)
+    raise ProviderProtocolError(
+        provider="telegram",
+        operation=operation,
+        reason="response message_id is invalid",
+    )
+
+
+def _reply_target(target_id: str) -> tuple[int, int]:
+    target = required_id(target_id, field="target_id")
+    if ":" not in target:
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation="parse_reply_target",
+            reason="target must contain chat_id:message_id",
+        )
+    chat_raw, message_raw = target.rsplit(":", 1)
+    try:
+        chat_id = int(chat_raw)
+        message_id = int(message_raw)
+    except ValueError:
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation="parse_reply_target",
+            reason="target ids must be integers",
+        ) from None
+    if message_id <= 0:
+        raise ProviderProtocolError(
+            provider="telegram",
+            operation="parse_reply_target",
+            reason="message_id must be positive",
+        )
+    return chat_id, message_id
+
+
+class TelegramBotClient:
+    """Implements reply and supervisor transport protocols via injected HTTP."""
+
+    def __init__(
+        self,
+        *,
+        http: httpx.AsyncClient,
+        permit: SandboxExecutionPermit | None,
+        bot_token: str,
+        supervisor_chat_id: str,
+    ) -> None:
+        self._http = http
+        self._permit = permit
+        self._bot_token = _bot_token(bot_token)
+        self._supervisor_chat_id = required_id(
+            supervisor_chat_id,
+            field="supervisor_chat_id",
+        )
+
+    def _send_message_url(self) -> str:
+        encoded_token = quote(self._bot_token, safe=":")
+        return f"{_TELEGRAM_API_BASE}/bot{encoded_token}/sendMessage"
+
+    async def reply_to_message(self, target_id: str, text: str) -> str:
+        chat_id, message_id = _reply_target(target_id)
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="telegram",
+            operation="reply_to_message",
+            method="POST",
+            url=self._send_message_url(),
+            json_body={
+                "chat_id": chat_id,
+                "text": reply_text(text),
+                "reply_parameters": {"message_id": message_id},
+            },
+        )
+        return _message_id(payload, operation="reply_to_message")
+
+    async def send_supervisor_message(self, text: str) -> str:
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="telegram",
+            operation="send_supervisor_message",
+            method="POST",
+            url=self._send_message_url(),
+            json_body={
+                "chat_id": self._supervisor_chat_id,
+                "text": required_text(text, field="supervisor_text"),
+            },
+        )
+        return _message_id(payload, operation="send_supervisor_message")

--- a/app/integrations/live/telegram.py
+++ b/app/integrations/live/telegram.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import httpx
 
 from app.adapters.platforms.common import reply_text, required_id, required_text
+from app.adapters.platforms.telegram import TelegramReplyClient, TelegramSupervisorClient
 from app.integrations.live.activation import SandboxExecutionPermit
 from app.integrations.live.base import ProviderProtocolError, request_json
 
@@ -82,8 +83,8 @@ def _reply_target(target_id: str) -> tuple[int, int]:
     return chat_id, message_id
 
 
-class TelegramBotClient:
-    """Implements reply and supervisor transport protocols via injected HTTP."""
+class TelegramBotClient(TelegramReplyClient, TelegramSupervisorClient):
+    """Reply and supervisor transport implementation via injected HTTP."""
 
     def __init__(
         self,

--- a/app/integrations/live/youtube.py
+++ b/app/integrations/live/youtube.py
@@ -1,0 +1,135 @@
+"""Sandbox-capable YouTube Data API comment polling and reply client."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+import httpx
+
+from app.adapters.platforms.common import optional_id, reply_text, required_id
+from app.adapters.platforms.live_security import YouTubePollingPolicy
+from app.integrations.live.activation import SandboxExecutionPermit
+from app.integrations.live.base import ProviderProtocolError, request_json, required_response_id
+
+_YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+
+class YouTubeAccessTokenProvider(Protocol):
+    """Provides a short-lived OAuth access token outside this HTTP client."""
+
+    async def get_access_token(self) -> str:
+        """Return one current OAuth access token."""
+        ...
+
+
+def _access_token(value: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ProviderProtocolError(
+            provider="youtube",
+            operation="authorize",
+            reason="missing or invalid access token",
+        )
+    if len(value) > 8192:
+        raise ProviderProtocolError(
+            provider="youtube",
+            operation="authorize",
+            reason="access token exceeds maximum length",
+        )
+    return value
+
+
+class YouTubeDataClient:
+    """Implements polling/reply calls using an injected HTTP and token provider."""
+
+    def __init__(
+        self,
+        *,
+        http: httpx.AsyncClient,
+        permit: SandboxExecutionPermit | None,
+        token_provider: YouTubeAccessTokenProvider,
+        polling_policy: YouTubePollingPolicy | None = None,
+    ) -> None:
+        self._http = http
+        self._permit = permit
+        self._token_provider = token_provider
+        self._polling_policy = polling_policy or YouTubePollingPolicy()
+
+    async def _authorization_header(self) -> Mapping[str, str]:
+        token = _access_token(await self._token_provider.get_access_token())
+        return {"Authorization": f"Bearer {token}"}
+
+    async def list_comment_threads(
+        self,
+        *,
+        video_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ) -> Mapping[str, Any]:
+        video = required_id(video_id, field="video_id")
+        page = optional_id(page_token, field="page_token")
+        limit = max_results or self._polling_policy.max_results_per_page
+        if not 1 <= limit <= self._polling_policy.max_results_per_page:
+            raise ProviderProtocolError(
+                provider="youtube",
+                operation="list_comment_threads",
+                reason="max_results exceeds configured polling policy",
+            )
+
+        params: dict[str, str | int] = {
+            "part": "snippet,replies",
+            "videoId": video,
+            "maxResults": limit,
+        }
+        if page is not None:
+            params["pageToken"] = page
+
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="youtube",
+            operation="list_comment_threads",
+            method="GET",
+            url=f"{_YOUTUBE_API_BASE}/commentThreads",
+            headers=await self._authorization_header(),
+            params=params,
+        )
+        items = payload.get("items")
+        if not isinstance(items, list):
+            raise ProviderProtocolError(
+                provider="youtube",
+                operation="list_comment_threads",
+                reason="response items must be a list",
+            )
+        next_page = payload.get("nextPageToken")
+        if next_page is not None and not isinstance(next_page, str):
+            raise ProviderProtocolError(
+                provider="youtube",
+                operation="list_comment_threads",
+                reason="nextPageToken must be a string when present",
+            )
+        return payload
+
+    async def reply_to_comment(self, comment_id: str, text: str) -> str:
+        parent_id = required_id(comment_id, field="comment_id")
+        payload = await request_json(
+            http=self._http,
+            permit=self._permit,
+            provider="youtube",
+            operation="reply_to_comment",
+            method="POST",
+            url=f"{_YOUTUBE_API_BASE}/comments",
+            headers=await self._authorization_header(),
+            params={"part": "snippet"},
+            json_body={
+                "snippet": {
+                    "parentId": parent_id,
+                    "textOriginal": reply_text(text),
+                }
+            },
+        )
+        return required_response_id(
+            payload,
+            provider="youtube",
+            operation="reply_to_comment",
+        )

--- a/app/integrations/live/youtube.py
+++ b/app/integrations/live/youtube.py
@@ -9,7 +9,10 @@ import httpx
 
 from app.adapters.platforms.common import optional_id, reply_text, required_id
 from app.adapters.platforms.live_security import YouTubePollingPolicy
-from app.integrations.live.activation import SandboxExecutionPermit
+from app.integrations.live.activation import (
+    SandboxExecutionPermit,
+    require_sandbox_execution,
+)
 from app.integrations.live.base import ProviderProtocolError, request_json, required_response_id
 
 _YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
@@ -56,6 +59,7 @@ class YouTubeDataClient:
         self._polling_policy = polling_policy or YouTubePollingPolicy()
 
     async def _authorization_header(self) -> Mapping[str, str]:
+        require_sandbox_execution(self._permit)
         token = _access_token(await self._token_provider.get_access_token())
         return {"Authorization": f"Bearer {token}"}
 
@@ -68,7 +72,11 @@ class YouTubeDataClient:
     ) -> Mapping[str, Any]:
         video = required_id(video_id, field="video_id")
         page = optional_id(page_token, field="page_token")
-        limit = max_results or self._polling_policy.max_results_per_page
+        limit = (
+            self._polling_policy.max_results_per_page
+            if max_results is None
+            else max_results
+        )
         if not 1 <= limit <= self._polling_policy.max_results_per_page:
             raise ProviderProtocolError(
                 provider="youtube",

--- a/app/integrations/live/youtube.py
+++ b/app/integrations/live/youtube.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.adapters.platforms.common import optional_id, reply_text, required_id
 from app.adapters.platforms.live_security import YouTubePollingPolicy
+from app.adapters.platforms.youtube import YouTubeReplyClient
 from app.integrations.live.activation import (
     SandboxExecutionPermit,
     require_sandbox_execution,
@@ -42,8 +43,8 @@ def _access_token(value: str) -> str:
     return value
 
 
-class YouTubeDataClient:
-    """Implements polling/reply calls using an injected HTTP and token provider."""
+class YouTubeDataClient(YouTubeReplyClient):
+    """YouTube reply protocol plus comment-thread polling through injected HTTP."""
 
     def __init__(
         self,

--- a/app/services/integration_readiness.py
+++ b/app/services/integration_readiness.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 
 from app.adapters.platforms.live_security import (
     WebhookVerificationError,
+    validate_meta_graph_api_version,
     validate_telegram_webhook_secret,
 )
 from app.config import Settings
@@ -55,12 +56,14 @@ class IntegrationReadinessService:
     def _required_values(self, target: IntegrationTarget) -> tuple[tuple[str, str | None], ...]:
         values: dict[IntegrationTarget, tuple[tuple[str, str | None], ...]] = {
             IntegrationTarget.FACEBOOK: (
+                ("META_GRAPH_API_VERSION", self.settings.meta_graph_api_version),
                 ("META_PAGE_ID", self.settings.meta_page_id),
                 ("META_ACCESS_TOKEN", self.settings.meta_access_token),
                 ("META_APP_SECRET", self.settings.meta_app_secret),
                 ("META_VERIFY_TOKEN", self.settings.meta_verify_token),
             ),
             IntegrationTarget.INSTAGRAM: (
+                ("META_GRAPH_API_VERSION", self.settings.meta_graph_api_version),
                 ("INSTAGRAM_BUSINESS_ACCOUNT_ID", self.settings.instagram_business_account_id),
                 ("META_ACCESS_TOKEN", self.settings.meta_access_token),
                 ("META_APP_SECRET", self.settings.meta_app_secret),
@@ -88,6 +91,13 @@ class IntegrationReadinessService:
 
     def _invalid_variables(self, target: IntegrationTarget) -> tuple[str, ...]:
         invalid: list[str] = []
+        if target in {IntegrationTarget.FACEBOOK, IntegrationTarget.INSTAGRAM}:
+            version = self.settings.meta_graph_api_version
+            if version is not None and version.strip():
+                try:
+                    validate_meta_graph_api_version(version)
+                except WebhookVerificationError:
+                    invalid.append("META_GRAPH_API_VERSION")
         if target is IntegrationTarget.TELEGRAM:
             secret = self.settings.telegram_webhook_secret
             if secret is not None and secret.strip():

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-V1 is a single Python service that coordinates comment/message handling for Facebook, Instagram, Telegram, and YouTube. External integrations stay behind adapters, and the existing fatwa bot remains behind a narrow integration boundary.
+V1 is a single Python service that coordinates comment/message handling for Facebook, Instagram, Telegram, and YouTube. External integrations stay behind adapters, and the supervised FATWA system remains behind a narrow integration boundary.
 
 ## High-level flow
 
@@ -27,13 +27,13 @@ Shadow Mode observes the same durable decision evidence in a separate read/audit
 
 ### HTTP application
 
-FastAPI owns health endpoints and, in later phases, inbound webhook endpoints. Importing or starting the application must not require production credentials.
+FastAPI owns health endpoints and, in later phases, authenticated inbound webhook endpoints. Importing or starting the application must not require production credentials or create network side effects.
 
 ### Platform adapters
 
 Facebook, Instagram, Telegram, and YouTube integrations implement provider-specific adapter modules while domain/services remain provider-neutral.
 
-Phase 6 implements only pure normalization plus injected client protocols. It deliberately does not implement production OAuth, webhook verification, polling, token refresh, or network clients. Stable inbound identities are normalized as follows:
+Phase 6 implements pure normalization plus injected client protocols. Stable inbound identities are normalized as follows:
 
 - Facebook: comment id.
 - Instagram: comment id.
@@ -135,11 +135,11 @@ pending_dispatch -> awaiting_response -> responded
 
 One accepted human response is allowed per escalation. Duplicate identical provider updates are idempotent; conflicting response or transport evidence fails closed.
 
-### Fatwa bot bridge
+### FATWA bridge
 
 A `FATWA` classification is only a routing decision and never contains a religious answer. Gheras cannot generate, rewrite, summarize, infer, complete, or improve a fatwa.
 
-Phase 7 adds a durable bridge boundary to an external supervised fatwa system. Eligibility requires an exact durable classification route of `FATWA`. The request lifecycle is:
+Phase 7 adds a durable bridge boundary to an external supervised FATWA system. Eligibility requires an exact durable classification route of `FATWA`. The request lifecycle is:
 
 ```text
 pending_dispatch -> awaiting_result -> approved_result
@@ -148,15 +148,15 @@ pending_dispatch -> awaiting_result -> approved_result
        └──────────────────┴────> cancelled
 ```
 
-The bridge prepares only minimal normalized question/identity data and performs no live call in this phase. Failed dispatch attempts increment a counter without storing raw provider errors. Successful dispatch records only a stable bridge name and external case id.
+The bridge prepares only minimal normalized question/identity data. Failed dispatch attempts increment a counter without storing raw provider errors. Successful dispatch records only a stable bridge name and external case id.
 
 A bridge result becomes publishable evidence only when the external result is `approved` and includes all of: non-empty answer text supplied by the supervised system, a non-empty `approved_by` value, a non-empty `source_ref`, and a stable unique external result key. A rejected result is structurally forbidden from carrying answer text or an approver.
 
-`fatwa_bridge_results` preserves the exact approved external text; Gheras does not transform it. Duplicate identical results are idempotent, while reuse of a request/result key with different semantics fails closed. The existing `telegram-fatwa-bot-v2` runtime and repository remain untouched until a separate Live Integration human gate.
+`fatwa_bridge_results` preserves the exact approved external text; Gheras does not transform it. Duplicate identical results are idempotent, while reuse of a request/result key with different semantics fails closed.
 
 ### Publishing dispatcher
 
-Phase 8 implements exact-source, mock-first origin publishing. Publication is permitted only from one of three durable sources:
+Phase 8 implements exact-source origin publishing. Publication is permitted only from one of three durable sources:
 
 - a `resolved` FAQ resolution whose exact referenced FAQ entry is still `active` at dispatch time;
 - a supervisor escalation in `responded` state with its single accepted human response;
@@ -175,7 +175,7 @@ A durable `outbound_actions` intent is created before any provider call. A worke
 
 If a provider call succeeds, the stable external result id is stored and later duplicate dispatch requests return the same durable `succeeded` action without another provider call. If an exception occurs after the provider attempt begins, the action becomes `uncertain`; it is never automatically retried because the external side effect may already have occurred. `dispatching` and `uncertain` require explicit reconciliation rather than blind resend.
 
-The default FATWA publication policy is `telegram_only`, so approved fatwa text is not automatically posted back to the origin comment unless a separate explicit policy configuration permits it. Phase 8 still uses injected/mock publishers only and performs no live platform publication.
+The default FATWA publication policy is `telegram_only`, so approved FATWA text is not automatically posted back to the origin comment unless a separate explicit policy configuration permits it.
 
 ### Shadow Mode boundary
 
@@ -197,11 +197,42 @@ Only `would_publish` may persist `source_kind`, `evidence_id`, and `proposed_tex
 
 Shadow evaluation does not create or claim `outbound_actions`, does not transition inbound processing state, and does not call adapters. Aggregate reporting exposes only counts by platform, route, and outcome plus publishable/non-publishable totals; it does not expose proposed reply text.
 
+### Pre-live security and readiness boundary
+
+Phase 10 establishes the pre-live regression/readiness gate. It verifies that mock-first core behavior remains isolated from provider networks, tracks unresolved Human Gates explicitly, and refuses to classify the system as production-ready merely because functional CI is green.
+
+Phase 11 retires the legacy scheduled/runtime path on the future active code line after the owner confirmed that the old bot is already stopped. It also adds pure provider security/readiness contracts: Meta webhook handshake/signature verification over raw bytes, Telegram webhook-secret validation, YouTube polling/quota metadata, and redaction-safe configuration readiness. Phase 11 cannot authorize live activation.
+
+### Sandbox live-network boundary
+
+Phase 12 introduces the first HTTP-capable provider implementations under the dedicated `app/integrations/live/` package. Network libraries and hard-coded provider endpoints are forbidden elsewhere by regression tests.
+
+The Phase 12 clients implement the existing Phase 6 protocols for:
+
+- Facebook Graph API comment replies;
+- Instagram Graph API comment replies;
+- Telegram reply and supervisor-message transport;
+- YouTube comment-thread polling and comment replies.
+
+Execution remains disabled by default. Every request requires an explicitly injected `SandboxExecutionPermit`; configuration or environment variables alone cannot create that permit, and Phase 12 defines no production permit. YouTube checks the permit before invoking its access-token provider.
+
+The shared HTTP boundary enforces:
+
+- HTTPS only;
+- exact provider-host allowlisting (`graph.facebook.com`, `api.telegram.org`, `www.googleapis.com`);
+- no URL userinfo, fragments, or non-443 ports;
+- redirects rejected instead of followed;
+- bounded provider-response bodies;
+- redacted transport/HTTP/protocol errors that do not include provider URLs, bodies, or credential values;
+- retryability limited to HTTP 429 and 5xx classification.
+
+Meta Graph API version is explicit configuration (`META_GRAPH_API_VERSION`) and must match the constrained `vN.N` form; no silent default is embedded in routing logic. Phase 12 tests provider request contracts exclusively through `httpx.MockTransport`; CI performs no provider calls.
+
 ## Reliability rules
 
 - Persist first, process later.
 - Inbound platform events are idempotent.
-- Moderation, classification, FAQ resolution, supervisor escalation, fatwa bridge state, and shadow audits are durable.
+- Moderation, classification, FAQ resolution, supervisor escalation, FATWA bridge state, and shadow audits are durable.
 - Duplicate/racing workers converge on one semantic durable result.
 - Outbound reply intents are persisted before external calls.
 - Concurrent publication workers cannot both claim the same pending action.
@@ -213,9 +244,11 @@ Shadow evaluation does not create or claim `outbound_actions`, does not transiti
 - External failure must not silently lose accepted work.
 - Low-confidence or uncertain routing escalates rather than guesses.
 - Possible religious content fails toward FATWA routing, never an AI-generated answer.
-- Fatwa text is publishable only after explicit external approval/provenance evidence.
+- FATWA text is publishable only after explicit external approval/provenance evidence.
 - Secrets come from environment variables and are never committed.
 - Raw external provider payloads are not blindly persisted.
+- Live-network code is isolated to the governed live-integration package.
+- Configuration presence never implies permission to perform an external action.
 
 ## Current implementation boundary
 
@@ -225,7 +258,10 @@ Shadow evaluation does not create or claim `outbound_actions`, does not transiti
 - Phase 3: mock-first routing-only classification with religious safety override.
 - Phase 4: versioned approved FAQ store and exact-key durable resolution.
 - Phase 5: durable human supervisor escalation/response workflow; no live Telegram calls.
-- Phase 6: mock-first four-platform normalizers and injected publisher/transport clients; no live network clients.
-- Phase 7: durable supervised fatwa bridge request/result lifecycle; no legacy-bot call or modification.
-- Phase 8: exact-source crash-safe publishing dispatcher with atomic claim and uncertainty freeze; injected publishers only, no live publication.
-- Phase 9: immutable side-effect-free Shadow Mode evaluation and aggregate audit reporting; no publishers, transports, outbound actions, or processing-state mutations.
+- Phase 6: four-platform normalizers and injected publisher/transport protocols.
+- Phase 7: durable supervised FATWA bridge request/result lifecycle.
+- Phase 8: exact-source crash-safe publishing dispatcher with atomic claim and uncertainty freeze.
+- Phase 9: immutable side-effect-free Shadow Mode evaluation and aggregate audit reporting.
+- Phase 10: pre-live security, regression, and final-readiness gate inventory.
+- Phase 11: live-integration security/readiness preparation plus owner-authorized active-code-line retirement of the legacy runtime path.
+- Phase 12: sandbox-capable Meta/Telegram/YouTube HTTP clients behind an explicit non-production execution permit; provider calls remain unexecuted in CI and no production activation path exists.

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -56,17 +56,25 @@ Credential values must never be posted in chat or committed to the repository.
 
 ## HG-05 — Live platform adapter implementation
 
-**Status:** PREPARATION IMPLEMENTED / NETWORK CLIENTS STILL DISABLED BY DESIGN
+**Status:** SANDBOX-CAPABLE CLIENTS IMPLEMENTED / REAL PROVIDER EXECUTION NOT YET VALIDATED
 
-Phase 11 adds provider-specific security/readiness contracts, including Meta webhook verification, Telegram webhook-secret validation, YouTube polling/quota metadata, environment configuration placeholders, and redaction-safe readiness evaluation.
+Phase 11 adds provider-specific webhook/readiness security contracts. Phase 12 adds HTTP-capable provider clients for Facebook, Instagram, Telegram, and YouTube behind the dedicated `app/integrations/live/` boundary.
 
-Real OAuth/token exchange, webhook registration, polling/network transport, token refresh, and provider HTTP clients remain outside the core and require sandbox validation before activation.
+These clients are still fail-closed for real execution:
+
+- every request requires an explicitly injected `SandboxExecutionPermit`;
+- configuration values cannot create that permit;
+- there is no production execution permit in Phase 12;
+- CI uses `httpx.MockTransport` only and performs no provider calls;
+- OAuth/token exchange, webhook registration, real polling, and provider-side permission/scope validation have not been executed.
+
+Real sandbox credentials and provider-side validation remain a Human Gate because they require external accounts/secrets and real network side effects.
 
 ## HG-06 — Supervised FATWA-system integration
 
 **Status:** NOT CONNECTED BY DESIGN
 
-The Phase 7 bridge remains a durable contract. No external FATWA runtime is called by Phase 11.
+The Phase 7 bridge remains a durable contract. No external FATWA runtime is called by Phases 11–12.
 
 The real connection requires authentication material, approved-result provenance verification, and failure/reconciliation validation in sandbox/staging before activation.
 

--- a/prompts/12_PHASE12_SANDBOX_LIVE_CLIENTS.md
+++ b/prompts/12_PHASE12_SANDBOX_LIVE_CLIENTS.md
@@ -1,0 +1,39 @@
+# Phase 12 — Sandbox-Capable Live Clients, Disabled by Default
+
+## Objective
+
+Implement provider HTTP clients behind a dedicated live-integration boundary while making accidental external execution impossible from ordinary application configuration.
+
+## Non-negotiable constraints
+
+- `app/integrations/live/` is the only application package allowed to import the HTTP client.
+- Domain, services, persistence, and pure platform adapters remain network-free.
+- Every live client requires both an explicitly injected `SandboxExecutionPermit` and an explicitly injected `httpx.AsyncClient`.
+- Phase 12 exposes no production execution permit.
+- No client creates its own default HTTP transport.
+- Provider hosts are fixed allowlisted HTTPS hosts; IDs/API versions are validated before URL construction.
+- Access tokens/secrets are never placed in exception messages.
+- Response bodies are never included in provider exceptions.
+- Tests use `httpx.MockTransport` only.
+- No real credential, webhook registration, OAuth grant, provider request, or production reply is performed.
+- Existing publication uncertainty semantics remain authoritative: a provider-call exception after dispatch begins is not blindly retried.
+
+## Verified provider operations (snapshot 2026-09-10)
+
+- Facebook Page comment reply: `POST /{comment-id}/comments` on Graph API with message text.
+- Instagram comment reply: `POST /{IG_COMMENT_ID}/replies` using the Instagram/Meta Graph surface.
+- Telegram message/reply: Bot API `sendMessage`, using `chat_id`, `text`, and `reply_parameters.message_id` when replying.
+- YouTube comment ingestion: `commentThreads.list`.
+- YouTube reply: `comments.insert` with `part=snippet`, `snippet.parentId`, and `snippet.textOriginal`.
+
+Meta Graph API version remains configuration and is not silently guessed by a client.
+
+## Exit criteria
+
+- Ruff, Mypy, and Pytest PASS on final head.
+- MockTransport tests prove exact method/path/body/header semantics without external network.
+- Missing execution permit fails before an HTTP request.
+- Provider errors are bounded and redaction-safe.
+- Security regression permits hardcoded provider URLs only under `app/integrations/live/` and only for approved hosts.
+- No production activation capability is added.
+- PR targets Phase 11, not `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ description = "Unified social comment routing service for Gheras"
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.116,<1.0",
+  "httpx>=0.28,<1.0",
   "uvicorn[standard]>=0.35,<1.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-  "httpx>=0.28,<1.0",
   "mypy>=1.17,<2.0",
   "pytest>=8.4,<9.0",
   "ruff>=0.12,<1.0",

--- a/tests/test_live_integration_prep.py
+++ b/tests/test_live_integration_prep.py
@@ -10,6 +10,7 @@ from app.adapters.platforms.live_security import (
     WebhookVerificationError,
     YouTubeIngestionMode,
     YouTubePollingPolicy,
+    validate_meta_graph_api_version,
     validate_telegram_webhook_secret,
     verify_meta_handshake,
     verify_meta_signature,
@@ -20,6 +21,13 @@ from app.domain.integrations import IntegrationReadinessState, IntegrationTarget
 from app.services.integration_readiness import IntegrationReadinessService
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_meta_graph_api_version_accepts_compact_version_only() -> None:
+    assert validate_meta_graph_api_version("v26.0") == "v26.0"
+    for invalid in ("26.0", "v26", "v26.0/evil", "https://evil.invalid", "v0.1"):
+        with pytest.raises(WebhookVerificationError):
+            validate_meta_graph_api_version(invalid)
 
 
 def test_meta_handshake_echoes_challenge_only_after_exact_token_match() -> None:
@@ -101,6 +109,7 @@ def test_youtube_polling_policy_uses_documented_preparation_snapshot() -> None:
 
 def _configured_settings(**overrides: object) -> Settings:
     values: dict[str, object] = {
+        "meta_graph_api_version": "v26.0",
         "meta_page_id": "page-id",
         "instagram_business_account_id": "ig-id",
         "telegram_supervisor_chat_id": "chat-id",
@@ -151,6 +160,15 @@ def test_readiness_lists_missing_variable_names_without_values() -> None:
     assert result.state is IntegrationReadinessState.MISSING_CONFIG
     assert result.missing_variables == ("META_ACCESS_TOKEN", "META_PAGE_ID")
     assert result.invalid_variables == ()
+
+
+def test_readiness_rejects_invalid_meta_version_shape() -> None:
+    settings = _configured_settings(meta_graph_api_version="v26.0/unsafe")
+    result = IntegrationReadinessService(settings).evaluate(IntegrationTarget.FACEBOOK)
+
+    assert result.state is IntegrationReadinessState.INVALID_CONFIG
+    assert result.invalid_variables == ("META_GRAPH_API_VERSION",)
+    assert result.live_activation_allowed is False
 
 
 def test_readiness_rejects_invalid_telegram_webhook_secret_shape() -> None:

--- a/tests/test_pre_live_security.py
+++ b/tests/test_pre_live_security.py
@@ -61,9 +61,12 @@ def _import_roots(path: Path) -> set[str]:
 def _url_literals(path: Path) -> set[str]:
     values: set[str] = set()
     for node in ast.walk(_tree(path)):
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            if node.value.startswith(("http://", "https://")):
-                values.add(node.value)
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.startswith(("http://", "https://"))
+        ):
+            values.add(node.value)
     return values
 
 

--- a/tests/test_pre_live_security.py
+++ b/tests/test_pre_live_security.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 APP_ROOT = PROJECT_ROOT / "app"
-CORE_ROOTS = (
-    APP_ROOT / "domain",
-    APP_ROOT / "services",
-    APP_ROOT / "persistence",
-    APP_ROOT / "adapters" / "platforms",
-)
+LIVE_ROOT = APP_ROOT / "integrations" / "live"
 
 FORBIDDEN_NETWORK_IMPORT_ROOTS = {
     "aiohttp",
@@ -29,20 +25,32 @@ LEGACY_IMPORT_ROOTS = {
     "database_config",
     "database_manager",
 }
+APPROVED_LIVE_HOSTS = {
+    "api.telegram.org",
+    "graph.facebook.com",
+    "www.googleapis.com",
+}
 
 
 def _python_files() -> list[Path]:
-    return sorted(path for root in CORE_ROOTS for path in root.rglob("*.py"))
+    return sorted(APP_ROOT.rglob("*.py"))
+
+
+def _non_live_python_files() -> list[Path]:
+    return [path for path in _python_files() if not path.is_relative_to(LIVE_ROOT)]
 
 
 def _case_id(value: Path) -> str:
     return str(value.relative_to(PROJECT_ROOT))
 
 
+def _tree(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
 def _import_roots(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     roots: set[str] = set()
-    for node in ast.walk(tree):
+    for node in ast.walk(_tree(path)):
         if isinstance(node, ast.Import):
             roots.update(alias.name.split(".", 1)[0] for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.module:
@@ -50,8 +58,17 @@ def _import_roots(path: Path) -> set[str]:
     return roots
 
 
-@pytest.mark.parametrize("path", _python_files(), ids=_case_id)
-def test_new_core_has_no_direct_network_client_imports(path: Path) -> None:
+def _url_literals(path: Path) -> set[str]:
+    values: set[str] = set()
+    for node in ast.walk(_tree(path)):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.startswith(("http://", "https://")):
+                values.add(node.value)
+    return values
+
+
+@pytest.mark.parametrize("path", _non_live_python_files(), ids=_case_id)
+def test_network_dependencies_are_confined_to_live_boundary(path: Path) -> None:
     imported = _import_roots(path)
     assert imported.isdisjoint(FORBIDDEN_NETWORK_IMPORT_ROOTS), (
         f"{path.relative_to(PROJECT_ROOT)} imports a forbidden live-network dependency: "
@@ -60,7 +77,7 @@ def test_new_core_has_no_direct_network_client_imports(path: Path) -> None:
 
 
 @pytest.mark.parametrize("path", _python_files(), ids=_case_id)
-def test_new_core_does_not_import_legacy_bot_modules(path: Path) -> None:
+def test_new_application_does_not_import_legacy_bot_modules(path: Path) -> None:
     imported = _import_roots(path)
     assert imported.isdisjoint(LEGACY_IMPORT_ROOTS), (
         f"{path.relative_to(PROJECT_ROOT)} imports legacy runtime code: "
@@ -68,13 +85,20 @@ def test_new_core_does_not_import_legacy_bot_modules(path: Path) -> None:
     )
 
 
-def test_new_application_contains_no_hardcoded_http_endpoints() -> None:
-    offenders: list[str] = []
-    for path in sorted(APP_ROOT.rglob("*.py")):
-        text = path.read_text(encoding="utf-8")
-        if "http://" in text or "https://" in text:
-            offenders.append(str(path.relative_to(PROJECT_ROOT)))
-    assert offenders == []
+@pytest.mark.parametrize("path", _non_live_python_files(), ids=_case_id)
+def test_hardcoded_http_endpoints_are_confined_to_live_boundary(path: Path) -> None:
+    assert _url_literals(path) == set()
+
+
+def test_live_boundary_uses_https_allowlisted_hosts_only() -> None:
+    observed: set[str] = set()
+    for path in sorted(LIVE_ROOT.rglob("*.py")):
+        for value in _url_literals(path):
+            parsed = urlparse(value)
+            assert parsed.scheme == "https"
+            assert parsed.hostname in APPROVED_LIVE_HOSTS
+            observed.add(parsed.hostname or "")
+    assert observed == APPROVED_LIVE_HOSTS
 
 
 def test_ci_workflow_does_not_consume_production_secrets() -> None:

--- a/tests/test_sandbox_live_clients.py
+++ b/tests/test_sandbox_live_clients.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from app.integrations.live.activation import (
+    ExternalIntegrationDisabled,
+    issue_sandbox_execution_permit,
+)
+from app.integrations.live.base import ProviderHTTPError, ProviderTransportError
+from app.integrations.live.meta import FacebookGraphReplyClient, InstagramGraphReplyClient
+from app.integrations.live.telegram import TelegramBotClient
+from app.integrations.live.youtube import YouTubeDataClient
+
+
+def _run(coro: object) -> object:
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+async def _with_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    callback: Callable[[httpx.AsyncClient], object],
+) -> object:
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        result = callback(http)
+        if hasattr(result, "__await__"):
+            return await result  # type: ignore[misc]
+        return result
+
+
+def test_facebook_reply_request_matches_verified_graph_contract() -> None:
+    token = "meta-sandbox-token"
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert request.method == "POST"
+        assert request.url.host == "graph.facebook.com"
+        assert request.url.path == "/v26.0/123_456/comments"
+        assert request.headers["authorization"] == f"Bearer {token}"
+        assert parse_qs(request.content.decode()) == {"message": ["جزاكم الله خيرًا"]}
+        return httpx.Response(200, json={"id": "facebook-reply-id"})
+
+    async def scenario(http: httpx.AsyncClient) -> str:
+        client = FacebookGraphReplyClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            access_token=token,
+            api_version="v26.0",
+        )
+        return await client.reply_to_comment("123_456", "جزاكم الله خيرًا")
+
+    result = _run(_with_client(handler, scenario))
+    assert result == "facebook-reply-id"
+    assert len(seen) == 1
+
+
+def test_instagram_reply_request_matches_verified_graph_contract() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.host == "graph.facebook.com"
+        assert request.url.path == "/v26.0/17890001/replies"
+        assert parse_qs(request.content.decode()) == {"message": ["أهلًا بكم"]}
+        return httpx.Response(200, json={"id": "instagram-reply-id"})
+
+    async def scenario(http: httpx.AsyncClient) -> str:
+        client = InstagramGraphReplyClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            access_token="meta-sandbox-token",
+            api_version="v26.0",
+        )
+        return await client.reply_to_comment("17890001", "أهلًا بكم")
+
+    assert _run(_with_client(handler, scenario)) == "instagram-reply-id"
+
+
+def test_telegram_reply_uses_send_message_reply_parameters() -> None:
+    token = "123456:telegram-sandbox-token"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.host == "api.telegram.org"
+        assert request.url.path == f"/bot{token}/sendMessage"
+        payload = json.loads(request.content)
+        assert payload == {
+            "chat_id": -100123,
+            "text": "تم الاستلام",
+            "reply_parameters": {"message_id": 77},
+        }
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 88}})
+
+    async def scenario(http: httpx.AsyncClient) -> str:
+        client = TelegramBotClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            bot_token=token,
+            supervisor_chat_id="-100999",
+        )
+        return await client.reply_to_message("-100123:77", "تم الاستلام")
+
+    assert _run(_with_client(handler, scenario)) == "88"
+
+
+def test_telegram_supervisor_transport_has_no_implicit_reply_target() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        assert payload == {"chat_id": "-100999", "text": "مراجعة بشرية مطلوبة"}
+        assert "reply_parameters" not in payload
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 901}})
+
+    async def scenario(http: httpx.AsyncClient) -> str:
+        client = TelegramBotClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            bot_token="123456:telegram-sandbox-token",
+            supervisor_chat_id="-100999",
+        )
+        return await client.send_supervisor_message("مراجعة بشرية مطلوبة")
+
+    assert _run(_with_client(handler, scenario)) == "901"
+
+
+class _TokenProvider:
+    def __init__(self, token: str = "youtube-sandbox-token") -> None:
+        self.token = token
+        self.calls = 0
+
+    async def get_access_token(self) -> str:
+        self.calls += 1
+        return self.token
+
+
+def test_youtube_list_and_reply_match_verified_data_api_contracts() -> None:
+    requests: list[httpx.Request] = []
+    token_provider = _TokenProvider()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.headers["authorization"] == "Bearer youtube-sandbox-token"
+        if request.url.path.endswith("/commentThreads"):
+            assert request.method == "GET"
+            assert request.url.params["part"] == "snippet,replies"
+            assert request.url.params["videoId"] == "video-123"
+            assert request.url.params["maxResults"] == "25"
+            assert request.url.params["pageToken"] == "page-2"
+            return httpx.Response(200, json={"items": [], "nextPageToken": "page-3"})
+
+        assert request.url.path.endswith("/comments")
+        assert request.method == "POST"
+        assert request.url.params["part"] == "snippet"
+        assert json.loads(request.content) == {
+            "snippet": {
+                "parentId": "comment-123",
+                "textOriginal": "نص الرد كما هو",
+            }
+        }
+        return httpx.Response(200, json={"id": "youtube-reply-id"})
+
+    async def scenario(http: httpx.AsyncClient) -> tuple[object, str]:
+        client = YouTubeDataClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            token_provider=token_provider,
+        )
+        page = await client.list_comment_threads(
+            video_id="video-123",
+            page_token="page-2",
+            max_results=25,
+        )
+        reply_id = await client.reply_to_comment("comment-123", "نص الرد كما هو")
+        return page, reply_id
+
+    page, reply_id = _run(_with_client(handler, scenario))  # type: ignore[misc]
+    assert page == {"items": [], "nextPageToken": "page-3"}
+    assert reply_id == "youtube-reply-id"
+    assert token_provider.calls == 2
+    assert len(requests) == 2
+
+
+def test_missing_permit_prevents_http_and_youtube_token_provider_calls() -> None:
+    http_calls = 0
+    token_provider = _TokenProvider()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal http_calls
+        http_calls += 1
+        return httpx.Response(500, request=request)
+
+    async def scenario(http: httpx.AsyncClient) -> None:
+        facebook = FacebookGraphReplyClient(
+            http=http,
+            permit=None,
+            access_token="meta-secret",
+            api_version="v26.0",
+        )
+        with pytest.raises(ExternalIntegrationDisabled):
+            await facebook.reply_to_comment("comment-1", "text")
+
+        youtube = YouTubeDataClient(
+            http=http,
+            permit=None,
+            token_provider=token_provider,
+        )
+        with pytest.raises(ExternalIntegrationDisabled):
+            await youtube.list_comment_threads(video_id="video-1")
+
+    _run(_with_client(handler, scenario))
+    assert http_calls == 0
+    assert token_provider.calls == 0
+
+
+def test_provider_http_error_is_redacted_and_retry_classified() -> None:
+    secret = "meta-super-secret-token"
+    response_secret = "do-not-leak-response-body"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text=response_secret, request=request)
+
+    async def scenario(http: httpx.AsyncClient) -> None:
+        client = FacebookGraphReplyClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            access_token=secret,
+            api_version="v26.0",
+        )
+        with pytest.raises(ProviderHTTPError) as exc_info:
+            await client.reply_to_comment("comment-1", "text")
+        error = exc_info.value
+        assert error.status_code == 503
+        assert error.retryable is True
+        rendered = repr(error) + str(error)
+        assert secret not in rendered
+        assert response_secret not in rendered
+        assert "graph.facebook.com" not in rendered
+
+    _run(_with_client(handler, scenario))
+
+
+def test_transport_error_does_not_leak_underlying_exception_text() -> None:
+    leaked = "transport-contained-secret"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(leaked, request=request)
+
+    async def scenario(http: httpx.AsyncClient) -> None:
+        client = InstagramGraphReplyClient(
+            http=http,
+            permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            access_token="meta-secret",
+            api_version="v26.0",
+        )
+        with pytest.raises(ProviderTransportError) as exc_info:
+            await client.reply_to_comment("comment-1", "text")
+        rendered = repr(exc_info.value) + str(exc_info.value)
+        assert leaked not in rendered
+        assert "meta-secret" not in rendered
+
+    _run(_with_client(handler, scenario))


### PR DESCRIPTION
## Summary

Closes Issue #28 as a stacked change above Phase 11.

### Provider clients
- adds HTTP-capable Facebook Graph API comment reply client
- adds HTTP-capable Instagram Graph API comment reply client
- adds Telegram reply and supervisor-message client
- adds YouTube comment-thread polling and comment-reply client
- binds implementations explicitly to the Phase 6 platform protocols

### Safety boundary
- network code is confined to `app/integrations/live/`
- all provider requests require an explicitly injected `SandboxExecutionPermit`
- configuration/environment values cannot create that permit
- Phase 12 defines no production execution permit
- YouTube validates permit before invoking its token provider
- HTTPS only; exact host allowlist
- non-443 ports, URL userinfo, fragments, and redirects are rejected
- provider response size is bounded
- provider errors are redacted and do not expose URL/body/credential values
- Meta Graph API version is explicit constrained configuration

### Validation
GitHub Actions run `34476337223` on head `cb0bae08fe0e13263adf7dc320332a75cec0a31b`:
- Ruff PASS
- Mypy PASS
- Pytest PASS

Tests use `httpx.MockTransport`; no provider API call, webhook registration, OAuth grant, credential use, or production publication was performed.

### Review boundary
This PR targets `phase/11-live-integration-prep`, not `main`. Independent review remains required before promotion.