### PR TITLE
Phase 13 — Authenticated Ingress & Collector Wiring

### DIFF
--- a/app/api/integrations.py
+++ b/app/api/integrations.py
@@ -1,0 +1,133 @@
+"""Explicitly constructed authenticated ingress router; unmounted by default."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import PlainTextResponse
+
+from app.adapters.platforms.live_security import (
+    WebhookVerificationError,
+    verify_meta_handshake,
+)
+from app.ingress.common import (
+    MAX_WEBHOOK_BODY_BYTES,
+    IngressBatchResult,
+    IngressConflict,
+    IngressPayloadError,
+)
+from app.ingress.meta import MetaWebhookIngress
+from app.ingress.telegram import TelegramWebhookIngress
+
+
+@dataclass(frozen=True, slots=True)
+class IngressRuntime:
+    """Explicit dependencies required to construct inbound webhook routes."""
+
+    meta: MetaWebhookIngress
+    telegram: TelegramWebhookIngress
+    meta_verify_token: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.meta_verify_token, str) or not self.meta_verify_token:
+            raise ValueError("Meta verify token must not be empty")
+
+
+def _summary(batch: IngressBatchResult) -> dict[str, int]:
+    return {
+        "accepted": batch.accepted_count,
+        "created": batch.created_count,
+        "duplicates": batch.duplicate_count,
+        "ignored": batch.ignored_count,
+    }
+
+
+def _require_json_content_type(request: Request) -> None:
+    media_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if media_type != "application/json":
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="application/json is required",
+        )
+
+
+async def _bounded_body(request: Request) -> bytes:
+    body = bytearray()
+    async for chunk in request.stream():
+        body.extend(chunk)
+        if len(body) > MAX_WEBHOOK_BODY_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="webhook body exceeds maximum size",
+            )
+    return bytes(body)
+
+
+def _translate_ingress_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, WebhookVerificationError):
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid webhook authentication",
+        )
+    if isinstance(exc, IngressConflict):
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="ingress identity conflict",
+        )
+    if isinstance(exc, IngressPayloadError):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid ingress payload",
+        )
+    raise exc
+
+
+def build_ingress_router(runtime: IngressRuntime) -> APIRouter:
+    """Build authenticated ingress routes without mounting them into the default app."""
+
+    router = APIRouter(prefix="/integrations", tags=["integrations"])
+
+    @router.get("/meta/webhook", response_class=PlainTextResponse)
+    async def meta_verify(request: Request) -> PlainTextResponse:
+        try:
+            challenge = verify_meta_handshake(
+                mode=request.query_params.get("hub.mode", ""),
+                verify_token=request.query_params.get("hub.verify_token", ""),
+                challenge=request.query_params.get("hub.challenge", ""),
+                expected_verify_token=runtime.meta_verify_token,
+            )
+        except WebhookVerificationError as exc:
+            raise _translate_ingress_error(exc) from None
+        return PlainTextResponse(challenge)
+
+    @router.post("/meta/webhook")
+    async def meta_webhook(request: Request) -> dict[str, int]:
+        _require_json_content_type(request)
+        body = await _bounded_body(request)
+        try:
+            batch = runtime.meta.ingest(
+                raw_body=body,
+                signature_header=request.headers.get("x-hub-signature-256", ""),
+            )
+        except (WebhookVerificationError, IngressPayloadError, IngressConflict) as exc:
+            raise _translate_ingress_error(exc) from None
+        return _summary(batch)
+
+    @router.post("/telegram/webhook")
+    async def telegram_webhook(request: Request) -> dict[str, int]:
+        _require_json_content_type(request)
+        body = await _bounded_body(request)
+        try:
+            batch = runtime.telegram.ingest(
+                raw_body=body,
+                secret_header=request.headers.get(
+                    "x-telegram-bot-api-secret-token",
+                    "",
+                ),
+            )
+        except (WebhookVerificationError, IngressPayloadError, IngressConflict) as exc:
+            raise _translate_ingress_error(exc) from None
+        return _summary(batch)
+
+    return router

--- a/app/api/integrations.py
+++ b/app/api/integrations.py
@@ -19,6 +19,10 @@ from app.ingress.common import (
 )
 from app.ingress.meta import MetaWebhookIngress
 from app.ingress.telegram import TelegramWebhookIngress
+from app.integrations.live.activation import (
+    SandboxExecutionPermit,
+    require_sandbox_execution,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,9 +87,14 @@ def _translate_ingress_error(exc: Exception) -> HTTPException:
     raise exc
 
 
-def build_ingress_router(runtime: IngressRuntime) -> APIRouter:
-    """Build authenticated ingress routes without mounting them into the default app."""
+def build_ingress_router(
+    runtime: IngressRuntime,
+    *,
+    permit: SandboxExecutionPermit | None = None,
+) -> APIRouter:
+    """Build sandbox ingress routes only after explicit capability issuance."""
 
+    require_sandbox_execution(permit)
     router = APIRouter(prefix="/integrations", tags=["integrations"])
 
     @router.get("/meta/webhook", response_class=PlainTextResponse)

--- a/app/ingress/__init__.py
+++ b/app/ingress/__init__.py
@@ -1,0 +1,1 @@
+"""Authenticated inbound provider boundaries for Gheras."""

--- a/app/ingress/common.py
+++ b/app/ingress/common.py
@@ -1,0 +1,148 @@
+"""Shared fail-closed helpers for authenticated inbound provider data."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from app.adapters.platforms.common import required_id, required_text
+from app.domain.events import InboundEvent, IngestionResult, NormalizedInboundEvent
+from app.services.ingestion import IngestionService
+
+MAX_WEBHOOK_BODY_BYTES = 1_000_000
+
+
+class IngressPayloadError(ValueError):
+    """Raised when authenticated provider input cannot be decoded safely."""
+
+
+class UnsupportedIngressEvent(IngressPayloadError):
+    """Raised when a provider object is outside the V1 ingress contract."""
+
+
+class IngressConflict(RuntimeError):
+    """Raised when one stable provider identity is reused with changed semantics."""
+
+
+@dataclass(frozen=True, slots=True)
+class IngressBatchResult:
+    """Redaction-safe batch result; no provider payload or user text is exposed."""
+
+    results: tuple[IngestionResult, ...]
+    ignored_count: int = 0
+
+    @property
+    def accepted_count(self) -> int:
+        return len(self.results)
+
+    @property
+    def created_count(self) -> int:
+        return sum(result.created for result in self.results)
+
+    @property
+    def duplicate_count(self) -> int:
+        return self.accepted_count - self.created_count
+
+
+def validate_raw_body(raw_body: bytes) -> bytes:
+    """Bound one raw webhook body before authentication or parsing work."""
+
+    if not isinstance(raw_body, bytes):
+        raise IngressPayloadError("webhook body must be bytes")
+    if not raw_body:
+        raise IngressPayloadError("webhook body must not be empty")
+    if len(raw_body) > MAX_WEBHOOK_BODY_BYTES:
+        raise IngressPayloadError("webhook body exceeds maximum size")
+    return raw_body
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise IngressPayloadError("JSON object contains duplicate keys")
+        result[key] = value
+    return result
+
+
+def load_json_object(raw_body: bytes) -> dict[str, Any]:
+    """Decode bounded UTF-8 JSON while rejecting duplicate object keys."""
+
+    body = validate_raw_body(raw_body)
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        raise IngressPayloadError("webhook body must be UTF-8 JSON") from None
+    try:
+        payload = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+    except IngressPayloadError:
+        raise
+    except json.JSONDecodeError:
+        raise IngressPayloadError("webhook body is not valid JSON") from None
+    if not isinstance(payload, dict):
+        raise IngressPayloadError("webhook JSON must be an object")
+    return payload
+
+
+def mapping(value: Any, *, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise IngressPayloadError(f"{field} must be an object")
+    return value
+
+
+def list_value(value: Any, *, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise IngressPayloadError(f"{field} must be a list")
+    return value
+
+
+def provider_id(value: Any, *, field: str) -> str:
+    """Preserve string ids and losslessly normalize integer JSON ids to decimal text."""
+
+    if isinstance(value, bool):
+        raise IngressPayloadError(f"{field} must be an identifier")
+    if isinstance(value, int):
+        value = str(value)
+    if not isinstance(value, str):
+        raise IngressPayloadError(f"{field} must be a string or integer")
+    try:
+        return required_id(value, field=field)
+    except ValueError as exc:
+        raise IngressPayloadError(str(exc)) from None
+
+
+def provider_text(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise IngressPayloadError(f"{field} must be a string")
+    try:
+        return required_text(value, field=field)
+    except ValueError as exc:
+        raise IngressPayloadError(str(exc)) from None
+
+
+def _same_semantics(stored: InboundEvent, proposed: NormalizedInboundEvent) -> bool:
+    """Compare immutable semantics while excluding delivery-only external_event_id."""
+
+    return (
+        stored.platform is proposed.platform
+        and stored.external_event_key == proposed.external_event_key
+        and stored.external_comment_id == proposed.external_comment_id
+        and stored.external_post_id == proposed.external_post_id
+        and stored.author_id == proposed.author_id
+        and stored.text == proposed.text
+        and stored.media == proposed.media
+    )
+
+
+class ExactIngestionCollector:
+    """Persist normalized events and reject semantic collisions on duplicate identities."""
+
+    def __init__(self, ingestion: IngestionService) -> None:
+        self.ingestion = ingestion
+
+    def ingest(self, event: NormalizedInboundEvent) -> IngestionResult:
+        result = self.ingestion.ingest_event(event)
+        if not result.created and not _same_semantics(result.event, event):
+            raise IngressConflict("provider event identity conflicts with durable semantics")
+        return result

--- a/app/ingress/common.py
+++ b/app/ingress/common.py
@@ -78,8 +78,8 @@ def load_json_object(raw_body: bytes) -> dict[str, Any]:
         payload = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
     except IngressPayloadError:
         raise
-    except json.JSONDecodeError:
-        raise IngressPayloadError("webhook body is not valid JSON") from None
+    except (json.JSONDecodeError, RecursionError):
+        raise IngressPayloadError("webhook body is not valid bounded JSON") from None
     if not isinstance(payload, dict):
         raise IngressPayloadError("webhook JSON must be an object")
     return payload

--- a/app/ingress/meta.py
+++ b/app/ingress/meta.py
@@ -1,0 +1,163 @@
+"""Authenticated Meta webhook decoding for Facebook and Instagram comments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.adapters.platforms.facebook import FacebookAdapter, FacebookCommentDTO
+from app.adapters.platforms.instagram import InstagramAdapter, InstagramCommentDTO
+from app.adapters.platforms.live_security import verify_meta_signature
+from app.domain.events import NormalizedInboundEvent
+from app.ingress.common import (
+    ExactIngestionCollector,
+    IngressBatchResult,
+    IngressPayloadError,
+    UnsupportedIngressEvent,
+    list_value,
+    load_json_object,
+    mapping,
+    provider_id,
+    provider_text,
+    validate_raw_body,
+)
+
+
+def _normalize_facebook(
+    *,
+    entry_id: str,
+    change: dict[str, Any],
+) -> tuple[NormalizedInboundEvent | None, bool]:
+    if change.get("field") != "feed":
+        return None, True
+    value = mapping(change.get("value"), field="facebook.change.value")
+    if value.get("item") != "comment" or value.get("verb") != "add":
+        return None, True
+    if "message" not in value:
+        return None, True
+
+    author = mapping(value.get("from"), field="facebook.change.value.from")
+    author_id = provider_id(author.get("id"), field="facebook.author_id")
+    if author_id == entry_id:
+        return None, True
+
+    try:
+        normalized = FacebookAdapter.normalize(
+            FacebookCommentDTO(
+                comment_id=provider_id(
+                    value.get("comment_id"),
+                    field="facebook.comment_id",
+                ),
+                post_id=provider_id(value.get("post_id"), field="facebook.post_id"),
+                author_id=author_id,
+                text=provider_text(value.get("message"), field="facebook.message"),
+            )
+        )
+    except ValueError as exc:
+        raise IngressPayloadError(str(exc)) from None
+    return normalized, False
+
+
+def _facebook_events(payload: dict[str, Any]) -> tuple[list[NormalizedInboundEvent], int]:
+    entries = list_value(payload.get("entry"), field="facebook.entry")
+    events: list[NormalizedInboundEvent] = []
+    ignored = 0
+    for raw_entry in entries:
+        entry = mapping(raw_entry, field="facebook.entry[]")
+        entry_id = provider_id(entry.get("id"), field="facebook.entry.id")
+        changes = list_value(entry.get("changes"), field="facebook.entry.changes")
+        for raw_change in changes:
+            change = mapping(raw_change, field="facebook.entry.changes[]")
+            normalized, was_ignored = _normalize_facebook(entry_id=entry_id, change=change)
+            if normalized is not None:
+                events.append(normalized)
+            ignored += int(was_ignored)
+    return events, ignored
+
+
+def _instagram_changes(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Support both documented direct field/value and batched changes envelopes."""
+
+    if "changes" in entry:
+        return [
+            mapping(value, field="instagram.entry.changes[]")
+            for value in list_value(entry.get("changes"), field="instagram.entry.changes")
+        ]
+    if "field" in entry or "value" in entry:
+        return [entry]
+    raise IngressPayloadError("instagram entry contains no change envelope")
+
+
+def _normalize_instagram(
+    *,
+    entry_id: str,
+    change: dict[str, Any],
+) -> tuple[NormalizedInboundEvent | None, bool]:
+    if change.get("field") != "comments":
+        return None, True
+    value = mapping(change.get("value"), field="instagram.change.value")
+    if "text" not in value:
+        return None, True
+
+    author = mapping(value.get("from"), field="instagram.change.value.from")
+    author_id = provider_id(author.get("id"), field="instagram.author_id")
+    if author_id == entry_id:
+        return None, True
+    media = mapping(value.get("media"), field="instagram.change.value.media")
+
+    try:
+        normalized = InstagramAdapter.normalize(
+            InstagramCommentDTO(
+                comment_id=provider_id(value.get("id"), field="instagram.comment_id"),
+                media_id=provider_id(media.get("id"), field="instagram.media_id"),
+                author_id=author_id,
+                text=provider_text(value.get("text"), field="instagram.text"),
+            )
+        )
+    except ValueError as exc:
+        raise IngressPayloadError(str(exc)) from None
+    return normalized, False
+
+
+def _instagram_events(payload: dict[str, Any]) -> tuple[list[NormalizedInboundEvent], int]:
+    entries = list_value(payload.get("entry"), field="instagram.entry")
+    events: list[NormalizedInboundEvent] = []
+    ignored = 0
+    for raw_entry in entries:
+        entry = mapping(raw_entry, field="instagram.entry[]")
+        entry_id = provider_id(entry.get("id"), field="instagram.entry.id")
+        for change in _instagram_changes(entry):
+            normalized, was_ignored = _normalize_instagram(entry_id=entry_id, change=change)
+            if normalized is not None:
+                events.append(normalized)
+            ignored += int(was_ignored)
+    return events, ignored
+
+
+class MetaWebhookIngress:
+    """Authenticate raw Meta bytes, decode supported comments, then persist normalized events."""
+
+    def __init__(self, *, collector: ExactIngestionCollector, app_secret: str) -> None:
+        if not isinstance(app_secret, str) or not app_secret:
+            raise ValueError("Meta app secret must not be empty")
+        self._collector = collector
+        self._app_secret = app_secret
+
+    def ingest(self, *, raw_body: bytes, signature_header: str) -> IngressBatchResult:
+        body = validate_raw_body(raw_body)
+        verify_meta_signature(
+            raw_body=body,
+            signature_header=signature_header,
+            app_secret=self._app_secret,
+        )
+        payload = load_json_object(body)
+
+        object_type = payload.get("object")
+        if object_type == "page":
+            events, ignored = _facebook_events(payload)
+        elif object_type == "instagram":
+            events, ignored = _instagram_events(payload)
+        else:
+            raise UnsupportedIngressEvent("unsupported Meta webhook object")
+
+        results = tuple(self._collector.ingest(event) for event in events)
+        return IngressBatchResult(results=results, ignored_count=ignored)

--- a/app/ingress/telegram.py
+++ b/app/ingress/telegram.py
@@ -1,0 +1,61 @@
+"""Authenticated Telegram webhook decoding for V1 text messages."""
+
+from __future__ import annotations
+
+from app.adapters.platforms.live_security import verify_telegram_webhook_secret
+from app.adapters.platforms.telegram import TelegramAdapter, TelegramMessageDTO
+from app.ingress.common import (
+    ExactIngestionCollector,
+    IngressBatchResult,
+    IngressPayloadError,
+    load_json_object,
+    mapping,
+    provider_id,
+    provider_text,
+    validate_raw_body,
+)
+
+
+class TelegramWebhookIngress:
+    """Verify Telegram's webhook secret before parsing and persist supported messages."""
+
+    def __init__(self, *, collector: ExactIngestionCollector, webhook_secret: str) -> None:
+        self._collector = collector
+        self._webhook_secret = webhook_secret
+
+    def ingest(self, *, raw_body: bytes, secret_header: str) -> IngressBatchResult:
+        body = validate_raw_body(raw_body)
+        verify_telegram_webhook_secret(
+            supplied_header=secret_header,
+            expected_secret=self._webhook_secret,
+        )
+        payload = load_json_object(body)
+
+        if "message" not in payload:
+            return IngressBatchResult(results=(), ignored_count=1)
+        message = mapping(payload.get("message"), field="telegram.message")
+        if "text" not in message:
+            return IngressBatchResult(results=(), ignored_count=1)
+
+        author = mapping(message.get("from"), field="telegram.message.from")
+        if author.get("is_bot") is True:
+            return IngressBatchResult(results=(), ignored_count=1)
+        chat = mapping(message.get("chat"), field="telegram.message.chat")
+
+        try:
+            normalized = TelegramAdapter.normalize(
+                TelegramMessageDTO(
+                    update_id=provider_id(payload.get("update_id"), field="telegram.update_id"),
+                    message_id=provider_id(
+                        message.get("message_id"),
+                        field="telegram.message_id",
+                    ),
+                    chat_id=provider_id(chat.get("id"), field="telegram.chat_id"),
+                    author_id=provider_id(author.get("id"), field="telegram.author_id"),
+                    text=provider_text(message.get("text"), field="telegram.text"),
+                )
+            )
+        except ValueError as exc:
+            raise IngressPayloadError(str(exc)) from None
+
+        return IngressBatchResult(results=(self._collector.ingest(normalized),))

--- a/app/ingress/youtube.py
+++ b/app/ingress/youtube.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from app.adapters.platforms.youtube import YouTubeAdapter, YouTubeCommentDTO
+from app.domain.events import NormalizedInboundEvent
 from app.ingress.common import (
     ExactIngestionCollector,
     IngressBatchResult,
@@ -60,7 +61,7 @@ def _decode_top_level_comment(
     *,
     expected_video_id: str,
     own_channel_id: str,
-) -> tuple[Any | None, bool]:
+) -> tuple[NormalizedInboundEvent | None, bool]:
     item = mapping(raw_item, field="youtube.items[]")
     thread_id = provider_id(item.get("id"), field="youtube.thread_id")
     thread_snippet = mapping(item.get("snippet"), field="youtube.thread.snippet")
@@ -127,7 +128,7 @@ class YouTubePollingIngress:
             raise IngressPayloadError("YouTube polling response must be an object")
 
         items = list_value(payload.get("items"), field="youtube.items")
-        normalized = []
+        normalized: list[NormalizedInboundEvent] = []
         ignored = 0
         for item in items:
             event, was_ignored = _decode_top_level_comment(

--- a/app/ingress/youtube.py
+++ b/app/ingress/youtube.py
@@ -1,0 +1,150 @@
+"""YouTube polling-to-durable-ingress coordinator."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from app.adapters.platforms.youtube import YouTubeAdapter, YouTubeCommentDTO
+from app.ingress.common import (
+    ExactIngestionCollector,
+    IngressBatchResult,
+    IngressPayloadError,
+    list_value,
+    mapping,
+    provider_id,
+    provider_text,
+)
+
+
+class YouTubeThreadSource(Protocol):
+    """Minimal source contract implemented by the Phase 12 YouTube client."""
+
+    async def list_comment_threads(
+        self,
+        *,
+        video_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ) -> Mapping[str, Any]:
+        """Return one provider comment-thread page."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class YouTubePollResult:
+    """Redaction-safe polling result without retaining the provider response."""
+
+    batch: IngressBatchResult
+    next_page_token: str | None
+
+
+def _comment_text(snippet: dict[str, Any]) -> str:
+    original = snippet.get("textOriginal")
+    if isinstance(original, str) and original.strip():
+        return provider_text(original, field="youtube.textOriginal")
+    return provider_text(snippet.get("textDisplay"), field="youtube.textDisplay")
+
+
+def _author_channel_id(snippet: dict[str, Any]) -> str:
+    author_channel = mapping(
+        snippet.get("authorChannelId"),
+        field="youtube.authorChannelId",
+    )
+    return provider_id(author_channel.get("value"), field="youtube.authorChannelId.value")
+
+
+def _decode_top_level_comment(
+    raw_item: Any,
+    *,
+    expected_video_id: str,
+    own_channel_id: str,
+) -> tuple[Any | None, bool]:
+    item = mapping(raw_item, field="youtube.items[]")
+    thread_id = provider_id(item.get("id"), field="youtube.thread_id")
+    thread_snippet = mapping(item.get("snippet"), field="youtube.thread.snippet")
+    video_id = provider_id(thread_snippet.get("videoId"), field="youtube.video_id")
+    if video_id != expected_video_id:
+        raise IngressPayloadError("YouTube response video id does not match polling target")
+
+    top_level = mapping(
+        thread_snippet.get("topLevelComment"),
+        field="youtube.topLevelComment",
+    )
+    comment_id = provider_id(top_level.get("id"), field="youtube.comment_id")
+    snippet = mapping(top_level.get("snippet"), field="youtube.comment.snippet")
+    try:
+        author_id = _author_channel_id(snippet)
+    except IngressPayloadError:
+        return None, True
+    if author_id == own_channel_id:
+        return None, True
+
+    try:
+        normalized = YouTubeAdapter.normalize(
+            YouTubeCommentDTO(
+                comment_id=comment_id,
+                video_id=video_id,
+                author_channel_id=author_id,
+                text=_comment_text(snippet),
+                thread_id=thread_id,
+            )
+        )
+    except ValueError as exc:
+        raise IngressPayloadError(str(exc)) from None
+    return normalized, False
+
+
+class YouTubePollingIngress:
+    """Poll supported top-level YouTube comments and persist normalized evidence."""
+
+    def __init__(
+        self,
+        *,
+        source: YouTubeThreadSource,
+        collector: ExactIngestionCollector,
+        own_channel_id: str,
+    ) -> None:
+        self._source = source
+        self._collector = collector
+        self._own_channel_id = provider_id(own_channel_id, field="youtube.own_channel_id")
+
+    async def poll_video(
+        self,
+        *,
+        video_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ) -> YouTubePollResult:
+        target_video = provider_id(video_id, field="youtube.poll_video_id")
+        payload = await self._source.list_comment_threads(
+            video_id=target_video,
+            page_token=page_token,
+            max_results=max_results,
+        )
+        if not isinstance(payload, Mapping):
+            raise IngressPayloadError("YouTube polling response must be an object")
+
+        items = list_value(payload.get("items"), field="youtube.items")
+        normalized = []
+        ignored = 0
+        for item in items:
+            event, was_ignored = _decode_top_level_comment(
+                item,
+                expected_video_id=target_video,
+                own_channel_id=self._own_channel_id,
+            )
+            if event is not None:
+                normalized.append(event)
+            ignored += int(was_ignored)
+
+        next_page = payload.get("nextPageToken")
+        if next_page is not None:
+            next_page = provider_id(next_page, field="youtube.nextPageToken")
+
+        results = tuple(self._collector.ingest(event) for event in normalized)
+        return YouTubePollResult(
+            batch=IngressBatchResult(results=results, ignored_count=ignored),
+            next_page_token=next_page,
+        )

--- a/app/integrations/live/youtube.py
+++ b/app/integrations/live/youtube.py
@@ -89,6 +89,7 @@ class YouTubeDataClient(YouTubeReplyClient):
             "part": "snippet,replies",
             "videoId": video,
             "maxResults": limit,
+            "textFormat": "plainText",
         }
         if page is not None:
             params["pageToken"] = page

--- a/docs/PHASE13_AUTHENTICATED_INGRESS.md
+++ b/docs/PHASE13_AUTHENTICATED_INGRESS.md
@@ -1,0 +1,67 @@
+# Phase 13 — Authenticated Ingress & Collector Wiring
+
+## Status
+
+Implementation gate: PASS on the Phase 13 branch after Ruff, Mypy, and Pytest.
+
+Production activation: NOT AUTHORIZED by this phase.
+
+## Boundary
+
+Phase 13 connects authenticated provider evidence to the existing durable inbound-event core without mounting provider routes in the default FastAPI application.
+
+### Meta
+
+- raw request bytes are bounded before processing;
+- `X-Hub-Signature-256` is verified before JSON parsing;
+- duplicate JSON object keys and pathological nesting fail closed;
+- Facebook and Instagram comment envelopes normalize through the existing Phase 6 adapters;
+- self-authored account comments are ignored;
+- raw provider payloads are not persisted.
+
+### Telegram
+
+- `X-Telegram-Bot-Api-Secret-Token` is verified before JSON parsing;
+- supported message evidence normalizes through the existing Telegram adapter;
+- bot-authored messages are ignored;
+- raw update payloads are not persisted.
+
+### YouTube
+
+- polling uses the Phase 12 YouTube client contract;
+- comment-thread requests explicitly request `textFormat=plainText`;
+- `textOriginal` is preferred when supplied by the provider, otherwise the returned plain-text display representation is preserved as received;
+- self-authored channel comments are ignored;
+- cross-video response evidence fails closed.
+
+## Durable semantics
+
+`ExactIngestionCollector` preserves Phase 1 persist-first idempotency while tightening duplicate semantics:
+
+- identical redelivery returns the existing durable event;
+- delivery-only `external_event_id` may differ across redelivery;
+- reuse of the same stable provider identity with changed author/post/text/media semantics raises `IngressConflict` rather than rewriting the stored event.
+
+Normalization stores only the provider identifiers and text required by the existing domain model. Raw webhook/update/provider response bodies are not stored.
+
+## Activation controls
+
+The default application does not mount provider ingress routes.
+
+`build_ingress_router()` additionally requires an explicit `SandboxExecutionPermit`, so route construction itself fails closed when the capability is absent. Environment/configuration presence alone cannot create this capability. No production permit exists in this phase.
+
+## Validation evidence
+
+Final pre-documentation implementation head: `6ba7f4615061c1e8bcae6ce395f5e2d8314708e3`.
+
+GitHub Actions run `34480298111`:
+
+- Ruff: PASS
+- Mypy: PASS
+- Pytest: PASS
+
+The suite covers authentication-before-parse, Arabic/Unicode preservation, duplicate/conflict behavior, raw-payload non-persistence, self/bot filtering, default-route absence, explicit sandbox route construction, bounded input handling, Meta/Telegram HTTP ingress behavior, and YouTube polling provenance.
+
+## Remaining external gate
+
+No webhook was registered, no OAuth grant was performed, no real provider credential was used, no provider API was called, and no publication occurred. Those remain outside Phase 13 and require a later explicitly governed external validation/cutover gate.

--- a/docs/PHASE13_REVIEW.md
+++ b/docs/PHASE13_REVIEW.md
@@ -1,0 +1,22 @@
+# Phase 13 — Adversarial Review
+
+Result: PASS for the non-production authenticated-ingress boundary.
+
+Reviewed against the Phase 12 base with emphasis on authentication ordering, durable idempotency, semantic collisions, payload retention, activation controls, and provider-specific normalization.
+
+Findings closed before lock:
+
+- malformed/unauthenticated input is authenticated before JSON parsing;
+- duplicate JSON keys and pathological nesting fail closed;
+- webhook bodies are bounded;
+- Meta/Telegram raw payloads are not persisted;
+- YouTube polling requests `textFormat=plainText` and cross-video evidence fails closed;
+- exact redelivery is idempotent while stable-identity semantic drift raises `IngressConflict`;
+- default FastAPI startup does not mount provider ingress routes;
+- constructing the optional ingress router itself requires an explicit `SandboxExecutionPermit`;
+- configuration/environment presence alone cannot authorize ingress activation;
+- no production permit, webhook registration, OAuth grant, real credential use, provider call, or publication path was added.
+
+Operational note: one provider delivery may contain multiple normalized events. Parsing/normalization is completed before persistence; each accepted normalized event is then protected by durable per-event idempotency. Production-scale batch transaction/reconciliation policy remains a later operational concern and is not represented as an atomic provider-batch guarantee.
+
+Independent external review is still required before promotion to `main`; this document records the in-project adversarial review and is not a substitute for an independent reviewer.

--- a/prompts/13_PHASE13_AUTHENTICATED_INGRESS.md
+++ b/prompts/13_PHASE13_AUTHENTICATED_INGRESS.md
@@ -1,0 +1,41 @@
+# Phase 13 — Authenticated Ingress & Collector Wiring
+
+## Objective
+
+Connect authenticated provider input to the existing normalized, persist-first event core without activating any external integration.
+
+## Governing rules
+
+- Meta POST authentication is verified over the exact raw body before JSON parsing.
+- Telegram webhook secret is verified before JSON parsing.
+- Webhook JSON is UTF-8, bounded, object-shaped, and rejects duplicate object keys.
+- Only supported V1 event shapes are normalized; unsupported/non-text/self-authored events create no durable action.
+- Facebook accepts Page `feed` comment `add` events only.
+- Instagram accepts `comments` events only.
+- Telegram accepts ordinary text `message` updates only and ignores bot-authored messages.
+- YouTube polling consumes the Phase 12 source contract and ingests supported top-level comments only.
+- Provider identifiers are preserved; integer JSON identifiers are losslessly represented as decimal strings.
+- Arabic/Unicode text is preserved verbatim from the selected provider field.
+- Raw provider payloads are never persisted.
+- Persist-first ingestion uses the existing durable repository.
+- Redelivery with identical semantics is idempotent.
+- Reuse of a stable event identity with changed durable semantics raises `IngressConflict`; original evidence is not rewritten.
+- The default FastAPI app must not mount provider webhook routes.
+- The ingress router requires explicit construction and dependency injection.
+- No credential provisioning, webhook registration, OAuth grant, real provider call, or outbound publication.
+
+## YouTube source-text rule
+
+The client explicitly requests `textFormat=plainText`. Use `snippet.textOriginal` when the provider returns it; otherwise use `snippet.textDisplay` exactly as returned. Do not claim that `textDisplay` is the original user-authored byte-for-byte text because YouTube documents that even plain-text display text can differ from the originally posted text.
+
+## Exit gate
+
+- Ruff PASS.
+- Mypy PASS.
+- Pytest PASS.
+- Authentication-before-parse tests PASS.
+- Duplicate/conflict tests PASS.
+- Raw-payload non-persistence test PASS.
+- Default-app unmounted-route test PASS.
+- No live provider network call in CI.
+- Independent review remains required before promotion.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import APIRouter
+
+from app.api.integrations import IngressRuntime
+from app.api.integrations import build_ingress_router as _build_ingress_router
+from app.integrations.live.activation import issue_sandbox_execution_permit
+
+
+@pytest.fixture(autouse=True)
+def _phase13_authenticated_ingress_router_harness(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Inject sandbox capability only into the Phase 13 HTTP-router test module."""
+
+    if request.module.__name__.endswith("test_authenticated_ingress"):
+
+        def _sandbox_router(runtime: IngressRuntime) -> APIRouter:
+            return _build_ingress_router(
+                runtime,
+                permit=issue_sandbox_execution_permit(purpose="sandbox_validation"),
+            )
+
+        monkeypatch.setattr(request.module, "build_ingress_router", _sandbox_router)
+
+    yield

--- a/tests/test_authenticated_ingress.py
+++ b/tests/test_authenticated_ingress.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.adapters.platforms.live_security import WebhookVerificationError
+from app.api.integrations import IngressRuntime, build_ingress_router
+from app.ingress.common import (
+    ExactIngestionCollector,
+    IngressConflict,
+    IngressPayloadError,
+)
+from app.ingress.meta import MetaWebhookIngress
+from app.ingress.telegram import TelegramWebhookIngress
+from app.ingress.youtube import YouTubePollingIngress
+from app.main import create_app
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.ingestion import IngestionService
+
+META_SECRET = "phase13-meta-secret"
+META_VERIFY_TOKEN = "phase13-meta-verify"
+TELEGRAM_SECRET = "Phase13_Telegram-Secret"
+
+
+def _services(
+    tmp_path: Path,
+) -> tuple[ExactIngestionCollector, DurableRepository, Path]:
+    database_path = tmp_path / "router.db"
+    database = SQLiteDatabase(database_path)
+    database.initialize()
+    repository = DurableRepository(database)
+    collector = ExactIngestionCollector(IngestionService(repository))
+    return collector, repository, database_path
+
+
+def _json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def _meta_signature(raw_body: bytes) -> str:
+    digest = hmac.new(META_SECRET.encode(), raw_body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _facebook_payload(*, text: str = "السلام عليكم") -> dict[str, Any]:
+    return {
+        "object": "page",
+        "entry": [
+            {
+                "id": "page-1",
+                "time": 1770000000,
+                "changes": [
+                    {
+                        "field": "feed",
+                        "value": {
+                            "item": "comment",
+                            "verb": "add",
+                            "comment_id": "fb-comment-1",
+                            "post_id": "fb-post-1",
+                            "from": {"id": "fb-user-1", "name": "ignored-name"},
+                            "message": text,
+                            "private_secret_marker": "RAW_PAYLOAD_MUST_NOT_PERSIST",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _telegram_payload(*, text: str = "مرحبا", is_bot: bool = False) -> dict[str, Any]:
+    return {
+        "update_id": 100,
+        "message": {
+            "message_id": 55,
+            "from": {"id": 42, "is_bot": is_bot, "first_name": "ignored"},
+            "chat": {"id": -777, "type": "private"},
+            "date": 1770000000,
+            "text": text,
+            "private_secret_marker": "TELEGRAM_RAW_MUST_NOT_PERSIST",
+        },
+    }
+
+
+def test_meta_authentication_runs_before_json_parse(tmp_path: Path) -> None:
+    collector, _, _ = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        ingress.ingest(
+            raw_body=b"{definitely-not-json",
+            signature_header="sha256=" + "0" * 64,
+        )
+
+
+def test_telegram_authentication_runs_before_json_parse(tmp_path: Path) -> None:
+    collector, _, _ = _services(tmp_path)
+    ingress = TelegramWebhookIngress(
+        collector=collector,
+        webhook_secret=TELEGRAM_SECRET,
+    )
+
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        ingress.ingest(raw_body=b"{not-json", secret_header="wrong-secret")
+
+
+def test_authenticated_facebook_comment_is_persisted_once_without_raw_payload(
+    tmp_path: Path,
+) -> None:
+    collector, repository, database_path = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+    raw = _json_bytes(_facebook_payload(text="السلام عليكم، متى يبدأ التسجيل؟"))
+
+    first = ingress.ingest(raw_body=raw, signature_header=_meta_signature(raw))
+    duplicate = ingress.ingest(raw_body=raw, signature_header=_meta_signature(raw))
+
+    assert first.accepted_count == 1
+    assert first.created_count == 1
+    assert duplicate.accepted_count == 1
+    assert duplicate.duplicate_count == 1
+    assert repository.count_events() == 1
+
+    event = first.results[0].event
+    assert event.external_comment_id == "fb-comment-1"
+    assert event.external_post_id == "fb-post-1"
+    assert event.author_id == "fb-user-1"
+    assert event.text == "السلام عليكم، متى يبدأ التسجيل؟"
+    assert event.media is None
+    assert b"RAW_PAYLOAD_MUST_NOT_PERSIST" not in database_path.read_bytes()
+
+
+def test_same_facebook_identity_with_changed_semantics_fails_closed(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+    first_raw = _json_bytes(_facebook_payload(text="النص الأصلي"))
+    changed_raw = _json_bytes(_facebook_payload(text="نص مختلف"))
+
+    ingress.ingest(raw_body=first_raw, signature_header=_meta_signature(first_raw))
+    with pytest.raises(IngressConflict, match="conflicts"):
+        ingress.ingest(
+            raw_body=changed_raw,
+            signature_header=_meta_signature(changed_raw),
+        )
+
+    assert repository.count_events() == 1
+    stored = repository.get_event(
+        ingress.ingest(
+            raw_body=first_raw,
+            signature_header=_meta_signature(first_raw),
+        ).results[0].event.id
+    )
+    assert stored.text == "النص الأصلي"
+
+
+def test_meta_rejects_duplicate_json_object_keys_after_authentication(tmp_path: Path) -> None:
+    collector, _, _ = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+    raw = b'{"object":"page","object":"instagram","entry":[]}'
+
+    with pytest.raises(IngressPayloadError, match="duplicate keys"):
+        ingress.ingest(raw_body=raw, signature_header=_meta_signature(raw))
+
+
+def test_instagram_comments_support_current_direct_field_envelope(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+    payload = {
+        "object": "instagram",
+        "entry": [
+            {
+                "id": "ig-owner-1",
+                "time": 1770000000,
+                "field": "comments",
+                "value": {
+                    "id": "ig-comment-1",
+                    "from": {"id": "ig-user-1", "username": "ignored"},
+                    "text": "تعليق إنستغرام كما هو",
+                    "media": {"id": "ig-media-1", "media_product_type": "REELS"},
+                },
+            }
+        ],
+    }
+    raw = _json_bytes(payload)
+
+    batch = ingress.ingest(raw_body=raw, signature_header=_meta_signature(raw))
+
+    assert batch.created_count == 1
+    assert repository.count_events() == 1
+    event = batch.results[0].event
+    assert event.external_comment_id == "ig-comment-1"
+    assert event.external_post_id == "ig-media-1"
+    assert event.author_id == "ig-user-1"
+    assert event.text == "تعليق إنستغرام كما هو"
+
+
+def test_instagram_comments_support_changes_envelope_and_ignore_self_comment(
+    tmp_path: Path,
+) -> None:
+    collector, repository, _ = _services(tmp_path)
+    ingress = MetaWebhookIngress(collector=collector, app_secret=META_SECRET)
+    payload = {
+        "object": "instagram",
+        "entry": [
+            {
+                "id": "ig-owner-1",
+                "changes": [
+                    {
+                        "field": "comments",
+                        "value": {
+                            "id": "ig-comment-self",
+                            "from": {"id": "ig-owner-1"},
+                            "text": "رد الحساب نفسه",
+                            "media": {"id": "ig-media-1"},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    raw = _json_bytes(payload)
+
+    batch = ingress.ingest(raw_body=raw, signature_header=_meta_signature(raw))
+
+    assert batch.accepted_count == 0
+    assert batch.ignored_count == 1
+    assert repository.count_events() == 0
+
+
+def test_authenticated_telegram_message_preserves_identity_and_text(tmp_path: Path) -> None:
+    collector, repository, database_path = _services(tmp_path)
+    ingress = TelegramWebhookIngress(
+        collector=collector,
+        webhook_secret=TELEGRAM_SECRET,
+    )
+    raw = _json_bytes(_telegram_payload(text="رسالة تيليجرام كما هي"))
+
+    first = ingress.ingest(raw_body=raw, secret_header=TELEGRAM_SECRET)
+    duplicate = ingress.ingest(raw_body=raw, secret_header=TELEGRAM_SECRET)
+
+    assert first.created_count == 1
+    assert duplicate.duplicate_count == 1
+    assert repository.count_events() == 1
+    event = first.results[0].event
+    assert event.external_event_key == "-777:55"
+    assert event.external_event_id == "100"
+    assert event.author_id == "42"
+    assert event.text == "رسالة تيليجرام كما هي"
+    assert b"TELEGRAM_RAW_MUST_NOT_PERSIST" not in database_path.read_bytes()
+
+
+def test_telegram_bot_authored_message_is_ignored(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    ingress = TelegramWebhookIngress(
+        collector=collector,
+        webhook_secret=TELEGRAM_SECRET,
+    )
+    raw = _json_bytes(_telegram_payload(is_bot=True))
+
+    batch = ingress.ingest(raw_body=raw, secret_header=TELEGRAM_SECRET)
+
+    assert batch.accepted_count == 0
+    assert batch.ignored_count == 1
+    assert repository.count_events() == 0
+
+
+class FakeYouTubeSource:
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, str | None, int | None]] = []
+
+    async def list_comment_threads(
+        self,
+        *,
+        video_id: str,
+        page_token: str | None = None,
+        max_results: int | None = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append((video_id, page_token, max_results))
+        return self.payload
+
+
+def _youtube_item(
+    *,
+    text_display: str,
+    text_original: str | None = None,
+    author_id: str = "yt-user-1",
+    video_id: str = "yt-video-1",
+) -> dict[str, Any]:
+    snippet: dict[str, Any] = {
+        "authorChannelId": {"value": author_id},
+        "textDisplay": text_display,
+    }
+    if text_original is not None:
+        snippet["textOriginal"] = text_original
+    return {
+        "id": "yt-thread-1",
+        "snippet": {
+            "videoId": video_id,
+            "topLevelComment": {
+                "id": "yt-comment-1",
+                "snippet": snippet,
+            },
+        },
+    }
+
+
+def test_youtube_poll_uses_provider_original_when_available(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    source = FakeYouTubeSource(
+        {
+            "items": [
+                _youtube_item(
+                    text_display="display representation",
+                    text_original="النص الأصلي من المزود",
+                )
+            ],
+            "nextPageToken": "next-page",
+        }
+    )
+    ingress = YouTubePollingIngress(
+        source=source,
+        collector=collector,
+        own_channel_id="yt-owner",
+    )
+
+    result = asyncio.run(
+        ingress.poll_video(
+            video_id="yt-video-1",
+            page_token="page-1",
+            max_results=25,
+        )
+    )
+
+    assert result.batch.created_count == 1
+    assert result.next_page_token == "next-page"
+    assert source.calls == [("yt-video-1", "page-1", 25)]
+    assert repository.count_events() == 1
+    assert result.batch.results[0].event.text == "النص الأصلي من المزود"
+
+
+def test_youtube_poll_falls_back_to_plain_text_display_and_ignores_self(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    source = FakeYouTubeSource(
+        {
+            "items": [
+                _youtube_item(text_display="تعليق متاح بصيغة العرض"),
+                {
+                    **_youtube_item(
+                        text_display="تعليق الحساب نفسه",
+                        author_id="yt-owner",
+                    ),
+                    "id": "yt-thread-self",
+                },
+            ]
+        }
+    )
+    ingress = YouTubePollingIngress(
+        source=source,
+        collector=collector,
+        own_channel_id="yt-owner",
+    )
+
+    result = asyncio.run(ingress.poll_video(video_id="yt-video-1"))
+
+    assert result.batch.created_count == 1
+    assert result.batch.ignored_count == 1
+    assert repository.count_events() == 1
+    assert result.batch.results[0].event.text == "تعليق متاح بصيغة العرض"
+
+
+def test_youtube_cross_video_payload_fails_closed(tmp_path: Path) -> None:
+    collector, repository, _ = _services(tmp_path)
+    source = FakeYouTubeSource(
+        {"items": [_youtube_item(text_display="text", video_id="wrong-video")]}
+    )
+    ingress = YouTubePollingIngress(
+        source=source,
+        collector=collector,
+        own_channel_id="yt-owner",
+    )
+
+    with pytest.raises(IngressPayloadError, match="does not match"):
+        asyncio.run(ingress.poll_video(video_id="yt-video-1"))
+    assert repository.count_events() == 0
+
+
+def test_default_application_does_not_mount_provider_ingress_routes() -> None:
+    paths = {route.path for route in create_app().routes}
+    assert "/integrations/meta/webhook" not in paths
+    assert "/integrations/telegram/webhook" not in paths
+
+
+def test_explicit_router_supports_meta_handshake_and_authenticated_ingress(
+    tmp_path: Path,
+) -> None:
+    collector, repository, _ = _services(tmp_path)
+    runtime = IngressRuntime(
+        meta=MetaWebhookIngress(collector=collector, app_secret=META_SECRET),
+        telegram=TelegramWebhookIngress(
+            collector=collector,
+            webhook_secret=TELEGRAM_SECRET,
+        ),
+        meta_verify_token=META_VERIFY_TOKEN,
+    )
+    app = FastAPI()
+    app.include_router(build_ingress_router(runtime))
+    client = TestClient(app)
+
+    verify = client.get(
+        "/integrations/meta/webhook",
+        params={
+            "hub.mode": "subscribe",
+            "hub.verify_token": META_VERIFY_TOKEN,
+            "hub.challenge": "123456",
+        },
+    )
+    assert verify.status_code == 200
+    assert verify.text == "123456"
+
+    raw = _json_bytes(_facebook_payload())
+    response = client.post(
+        "/integrations/meta/webhook",
+        content=raw,
+        headers={
+            "content-type": "application/json",
+            "x-hub-signature-256": _meta_signature(raw),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "accepted": 1,
+        "created": 1,
+        "duplicates": 0,
+        "ignored": 0,
+    }
+    assert repository.count_events() == 1
+
+
+def test_explicit_router_returns_generic_auth_error_without_parsing_body(
+    tmp_path: Path,
+) -> None:
+    collector, _, _ = _services(tmp_path)
+    runtime = IngressRuntime(
+        meta=MetaWebhookIngress(collector=collector, app_secret=META_SECRET),
+        telegram=TelegramWebhookIngress(
+            collector=collector,
+            webhook_secret=TELEGRAM_SECRET,
+        ),
+        meta_verify_token=META_VERIFY_TOKEN,
+    )
+    app = FastAPI()
+    app.include_router(build_ingress_router(runtime))
+    client = TestClient(app)
+
+    response = client.post(
+        "/integrations/meta/webhook",
+        content=b"{malformed-json",
+        headers={
+            "content-type": "application/json",
+            "x-hub-signature-256": "sha256=" + "0" * 64,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "invalid webhook authentication"}
+
+
+def test_explicit_router_rejects_non_json_content_type(tmp_path: Path) -> None:
+    collector, _, _ = _services(tmp_path)
+    runtime = IngressRuntime(
+        meta=MetaWebhookIngress(collector=collector, app_secret=META_SECRET),
+        telegram=TelegramWebhookIngress(
+            collector=collector,
+            webhook_secret=TELEGRAM_SECRET,
+        ),
+        meta_verify_token=META_VERIFY_TOKEN,
+    )
+    app = FastAPI()
+    app.include_router(build_ingress_router(runtime))
+    client = TestClient(app)
+
+    response = client.post(
+        "/integrations/telegram/webhook",
+        content=b"{}",
+        headers={
+            "content-type": "text/plain",
+            "x-telegram-bot-api-secret-token": TELEGRAM_SECRET,
+        },
+    )
+
+    assert response.status_code == 415

--- a/tests/test_authenticated_ingress.py
+++ b/tests/test_authenticated_ingress.py
@@ -395,7 +395,11 @@ def test_youtube_cross_video_payload_fails_closed(tmp_path: Path) -> None:
 
 
 def test_default_application_does_not_mount_provider_ingress_routes() -> None:
-    paths = {route.path for route in create_app().routes}
+    paths = {
+        path
+        for route in create_app().routes
+        if isinstance((path := getattr(route, "path", None)), str)
+    }
     assert "/integrations/meta/webhook" not in paths
     assert "/integrations/telegram/webhook" not in paths
 

--- a/tests/test_ingress_activation_gate.py
+++ b/tests/test_ingress_activation_gate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.api.integrations import IngressRuntime, build_ingress_router
+from app.ingress.common import ExactIngestionCollector
+from app.ingress.meta import MetaWebhookIngress
+from app.ingress.telegram import TelegramWebhookIngress
+from app.integrations.live.activation import ExternalIntegrationDisabled
+from app.persistence.repositories import DurableRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.ingestion import IngestionService
+
+
+def test_ingress_router_construction_requires_explicit_sandbox_capability(
+    tmp_path: Path,
+) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    collector = ExactIngestionCollector(IngestionService(DurableRepository(database)))
+    runtime = IngressRuntime(
+        meta=MetaWebhookIngress(collector=collector, app_secret="meta-secret"),
+        telegram=TelegramWebhookIngress(
+            collector=collector,
+            webhook_secret="Telegram_Secret-123",
+        ),
+        meta_verify_token="meta-verify-token",
+    )
+
+    with pytest.raises(ExternalIntegrationDisabled, match="permit is required"):
+        build_ingress_router(runtime)

--- a/tests/test_sandbox_live_clients.py
+++ b/tests/test_sandbox_live_clients.py
@@ -148,6 +148,7 @@ def test_youtube_list_and_reply_match_verified_data_api_contracts() -> None:
             assert request.url.params["part"] == "snippet,replies"
             assert request.url.params["videoId"] == "video-123"
             assert request.url.params["maxResults"] == "25"
+            assert request.url.params["textFormat"] == "plainText"
             assert request.url.params["pageToken"] == "page-2"
             return httpx.Response(200, json={"items": [], "nextPageToken": "page-3"})
 


### PR DESCRIPTION
## Summary

Closes Issue #30 as a stacked non-production change above Phase 12.

### Ingress boundary
- verifies Meta raw-body signature before JSON parsing;
- verifies Telegram webhook secret before parsing;
- decodes supported Facebook, Instagram, and Telegram comment/message evidence;
- adds YouTube polling-to-durable-ingress coordination;
- preserves Arabic/Unicode and stable provider identifiers;
- does not persist raw provider payloads.

### Durable safety
- exact redelivery is idempotent;
- stable provider identity reused with changed durable semantics raises `IngressConflict`;
- duplicate JSON keys, pathological nesting, malformed payloads, and cross-video YouTube evidence fail closed;
- self/bot-authored content is ignored where applicable.

### Activation controls
- default FastAPI app does not mount provider ingress routes;
- optional ingress router construction requires explicit `SandboxExecutionPermit`;
- no production permit exists;
- no webhook registration, OAuth grant, real provider credential, provider API call, or publication was performed.

### Validation
GitHub Actions run `34480532855` on clean locked head `26574f60aaf9d3d64b1af2f140ccfbfe44d9d203`:
- Ruff PASS
- Mypy PASS
- Pytest PASS

In-project adversarial review is documented but does not substitute for independent review. Promotion to `main` remains blocked pending independent review and the stacked promotion chain.