### PR TITLE
Phase 14 — End-to-End Sandbox Assembly & Replay Validation

### DIFF
--- a/app/sandbox/__init__.py
+++ b/app/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Side-effect-free sandbox composition and replay utilities."""

--- a/app/sandbox/replay.py
+++ b/app/sandbox/replay.py
@@ -1,0 +1,461 @@
+"""Side-effect-free end-to-end replay composition for Gheras V1."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from app.domain.classification import (
+    ClassificationAssessment,
+    ClassificationRequest,
+    ClassificationRoute,
+)
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.faq import FAQResolutionStatus
+from app.domain.fatwa import FatwaResultOutcome
+from app.domain.moderation import (
+    ModerationAssessment,
+    ModerationDisposition,
+    ModerationRequest,
+)
+from app.domain.publishing import (
+    FatwaPublicationPolicy,
+    PublicationSourceKind,
+    PublicationStatus,
+)
+from app.domain.shadow import ShadowOutcome
+from app.persistence.classification_repository import ClassificationRepository
+from app.persistence.faq_repository import FAQRepository
+from app.persistence.fatwa_repository import FatwaRepository
+from app.persistence.moderation_repository import ModerationRepository
+from app.persistence.publishing_repository import PublishingRepository
+from app.persistence.repositories import DurableRepository
+from app.persistence.shadow_repository import ShadowRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.persistence.supervisor_repository import SupervisorRepository
+from app.services.classification import ClassificationService
+from app.services.classification_policy import ClassificationPolicy
+from app.services.faq import FAQService
+from app.services.fatwa import FatwaService
+from app.services.ingestion import IngestionService
+from app.services.moderation import ModerationService
+from app.services.moderation_policy import ModerationPolicy
+from app.services.publishing import PublishingNotEligible, PublishingService
+from app.services.shadow import ShadowService
+from app.services.supervisor import SupervisorService
+from app.ingress.common import ExactIngestionCollector
+
+
+class ReplayEvidenceConflict(RuntimeError):
+    """Raised when replay evidence disagrees with already durable semantics."""
+
+
+class ReplayInvariantError(RuntimeError):
+    """Raised when composed V1 boundaries disagree during offline replay."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayFAQApproval:
+    faq_key: str
+    answer_text: str
+    source_ref: str
+    approved_by: str
+    approved_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReplaySupervisorEvidence:
+    transport_name: str
+    external_thread_id: str
+    external_response_key: str
+    supervisor_ref: str
+    text: str
+    received_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayFatwaEvidence:
+    bridge_name: str
+    external_case_id: str
+    external_result_key: str
+    outcome: FatwaResultOutcome
+    answer_text: str | None
+    approved_by: str | None
+    source_ref: str
+    received_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayScenario:
+    event: NormalizedInboundEvent
+    moderation: ModerationAssessment
+    classification: ClassificationAssessment | None = None
+    faq_approval: ReplayFAQApproval | None = None
+    supervisor: ReplaySupervisorEvidence | None = None
+    fatwa: ReplayFatwaEvidence | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedPublishCall:
+    platform: Platform
+    target_id: str
+    text_sha256: str
+    text_length: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    platform: Platform
+    created_event: bool
+    moderation_disposition: ModerationDisposition
+    route: ClassificationRoute | None
+    shadow_outcome: ShadowOutcome
+    source_kind: PublicationSourceKind | None
+    publication_status: PublicationStatus | None
+    provider_called: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayReport:
+    results: tuple[ReplayResult, ...]
+    provider_call_count: int
+    by_platform: dict[str, int]
+    by_route: dict[str, int]
+    by_shadow_outcome: dict[str, int]
+
+    @classmethod
+    def build(
+        cls,
+        results: tuple[ReplayResult, ...],
+        *,
+        provider_call_count: int,
+    ) -> ReplayReport:
+        return cls(
+            results=results,
+            provider_call_count=provider_call_count,
+            by_platform=dict(Counter(result.platform.value for result in results)),
+            by_route=dict(
+                Counter(
+                    result.route.value if result.route is not None else "none"
+                    for result in results
+                )
+            ),
+            by_shadow_outcome=dict(
+                Counter(result.shadow_outcome.value for result in results)
+            ),
+        )
+
+
+class _StaticModerationAdapter:
+    name = "sandbox-replay-moderation"
+    version = "1"
+
+    def __init__(self, assessment: ModerationAssessment) -> None:
+        self._assessment = assessment
+
+    async def assess(self, request: ModerationRequest) -> ModerationAssessment:
+        return self._assessment
+
+
+class _StaticClassificationAdapter:
+    name = "sandbox-replay-classification"
+    version = "1"
+
+    def __init__(self, assessment: ClassificationAssessment) -> None:
+        self._assessment = assessment
+
+    async def classify(self, request: ClassificationRequest) -> ClassificationAssessment:
+        return self._assessment
+
+
+class _RecordingPublisher:
+    """Record content fingerprints only; never retain replay text."""
+
+    def __init__(self, platform: Platform) -> None:
+        self.platform = platform
+        self.calls: list[RecordedPublishCall] = []
+
+    async def publish_reply(self, *, external_comment_id: str, text: str) -> str:
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        self.calls.append(
+            RecordedPublishCall(
+                platform=self.platform,
+                target_id=external_comment_id,
+                text_sha256=digest,
+                text_length=len(text),
+            )
+        )
+        identity = hashlib.sha256(
+            f"{self.platform.value}\0{external_comment_id}".encode("utf-8")
+        ).hexdigest()[:24]
+        return f"sandbox-{identity}"
+
+
+class SandboxReplayRuntime:
+    """Compose V1 services over SQLite without any external transport or network call."""
+
+    def __init__(
+        self,
+        database_path: Path,
+        *,
+        fatwa_policy: FatwaPublicationPolicy = FatwaPublicationPolicy.TELEGRAM_ONLY,
+        evaluator_version: str = "sandbox-replay-v1",
+    ) -> None:
+        self.database = SQLiteDatabase(database_path)
+        self.database.initialize()
+        self.events = DurableRepository(self.database)
+        self.moderation = ModerationRepository(self.database)
+        self.classifications = ClassificationRepository(self.database)
+        self.faqs = FAQRepository(self.database)
+        self.supervisors = SupervisorRepository(self.database)
+        self.fatwas = FatwaRepository(self.database)
+        self.publications = PublishingRepository(self.database)
+        self.shadows = ShadowRepository(self.database)
+        self.moderation_policy = ModerationPolicy(minimum_confidence=0.80)
+        self.classification_policy = ClassificationPolicy(minimum_faq_confidence=0.80)
+        self.fatwa_policy = fatwa_policy
+        self.evaluator_version = evaluator_version
+        self._publishers = {
+            platform: _RecordingPublisher(platform)
+            for platform in Platform
+        }
+
+    @property
+    def recorded_calls(self) -> tuple[RecordedPublishCall, ...]:
+        return tuple(
+            call
+            for platform in Platform
+            for call in self._publishers[platform].calls
+        )
+
+    async def replay(self, scenarios: Iterable[ReplayScenario]) -> ReplayReport:
+        before = len(self.recorded_calls)
+        results = tuple([await self.replay_one(scenario) for scenario in scenarios])
+        return ReplayReport.build(
+            results,
+            provider_call_count=len(self.recorded_calls) - before,
+        )
+
+    async def replay_one(self, scenario: ReplayScenario) -> ReplayResult:
+        ingestion = ExactIngestionCollector(IngestionService(self.events)).ingest(scenario.event)
+        event = ingestion.event
+
+        moderation_request = ModerationRequest(
+            event_id=event.id,
+            platform=event.platform,
+            text=event.text,
+            media=event.media,
+        )
+        expected_moderation = self.moderation_policy.decide(
+            moderation_request,
+            scenario.moderation,
+        )
+        moderation_result = await ModerationService(
+            events=self.events,
+            results=self.moderation,
+            adapter=_StaticModerationAdapter(scenario.moderation),
+            policy=self.moderation_policy,
+        ).moderate(event.id)
+        if (
+            moderation_result.disposition is not expected_moderation.disposition
+            or moderation_result.reasons != expected_moderation.reasons
+            or moderation_result.categories != scenario.moderation.categories
+            or moderation_result.confidence != scenario.moderation.confidence
+        ):
+            raise ReplayEvidenceConflict("durable moderation evidence differs from replay")
+
+        route: ClassificationRoute | None = None
+        if moderation_result.disposition is ModerationDisposition.ALLOW_ROUTING:
+            if scenario.classification is None:
+                raise ReplayInvariantError(
+                    "allow_routing replay requires classification evidence"
+                )
+            classification_request = ClassificationRequest(
+                event_id=event.id,
+                platform=event.platform,
+                text=event.text,
+                media=event.media,
+            )
+            expected_classification = self.classification_policy.decide(
+                classification_request,
+                scenario.classification,
+            )
+            classification_result = await ClassificationService(
+                events=self.events,
+                moderation=self.moderation,
+                results=self.classifications,
+                adapter=_StaticClassificationAdapter(scenario.classification),
+                policy=self.classification_policy,
+            ).classify(event.id)
+            if (
+                classification_result.route is not expected_classification.route
+                or classification_result.reasons != expected_classification.reasons
+                or classification_result.faq_key != expected_classification.faq_key
+                or classification_result.religious_possible
+                is not scenario.classification.religious_possible
+                or classification_result.confidence != scenario.classification.confidence
+            ):
+                raise ReplayEvidenceConflict(
+                    "durable classification evidence differs from replay"
+                )
+            route = classification_result.route
+            self._apply_route_evidence(event.id, route, scenario)
+        elif scenario.faq_approval or scenario.supervisor or scenario.fatwa:
+            raise ReplayEvidenceConflict(
+                "blocked or human-review moderation cannot accept downstream route evidence"
+            )
+
+        shadow = ShadowService(
+            events=self.events,
+            moderation=self.moderation,
+            classifications=self.classifications,
+            faqs=self.faqs,
+            supervisors=self.supervisors,
+            fatwas=self.fatwas,
+            shadows=self.shadows,
+            evaluator_version=self.evaluator_version,
+            fatwa_policy=self.fatwa_policy,
+        ).evaluate(event.id)
+
+        publication_status: PublicationStatus | None = None
+        provider_called = False
+        if shadow.outcome is ShadowOutcome.WOULD_PUBLISH:
+            try:
+                publication = await PublishingService(
+                    events=self.events,
+                    classifications=self.classifications,
+                    faqs=self.faqs,
+                    supervisors=self.supervisors,
+                    fatwas=self.fatwas,
+                    publications=self.publications,
+                    publishers=self._publishers,
+                    fatwa_policy=self.fatwa_policy,
+                ).dispatch_origin(event.id)
+            except PublishingNotEligible as exc:
+                raise ReplayInvariantError(
+                    "shadow would_publish disagrees with publishing eligibility"
+                ) from exc
+            publication_status = PublicationStatus(publication.action.status)
+            provider_called = publication.provider_called
+
+        return ReplayResult(
+            platform=event.platform,
+            created_event=ingestion.created,
+            moderation_disposition=moderation_result.disposition,
+            route=route,
+            shadow_outcome=shadow.outcome,
+            source_kind=shadow.source_kind,
+            publication_status=publication_status,
+            provider_called=provider_called,
+        )
+
+    def _apply_route_evidence(
+        self,
+        event_id: str,
+        route: ClassificationRoute,
+        scenario: ReplayScenario,
+    ) -> None:
+        if route is ClassificationRoute.FAQ:
+            if scenario.fatwa is not None:
+                raise ReplayEvidenceConflict("FAQ route cannot accept FATWA evidence")
+            if scenario.faq_approval is not None:
+                self._seed_faq(scenario.faq_approval)
+            resolution = FAQService(
+                classifications=self.classifications,
+                faqs=self.faqs,
+            ).resolve(event_id)
+            if scenario.supervisor is not None:
+                if resolution.resolution.status is not FAQResolutionStatus.SUPERVISOR_REQUIRED:
+                    raise ReplayEvidenceConflict(
+                        "resolved FAQ cannot also accept supervisor response evidence"
+                    )
+                self._apply_supervisor(event_id, scenario.supervisor)
+            return
+
+        if route is ClassificationRoute.SUPERVISOR:
+            if scenario.faq_approval is not None or scenario.fatwa is not None:
+                raise ReplayEvidenceConflict(
+                    "SUPERVISOR route cannot accept FAQ or FATWA evidence"
+                )
+            if scenario.supervisor is not None:
+                self._apply_supervisor(event_id, scenario.supervisor)
+            return
+
+        if scenario.faq_approval is not None or scenario.supervisor is not None:
+            raise ReplayEvidenceConflict("FATWA route cannot accept FAQ or supervisor evidence")
+        service = FatwaService(
+            events=self.events,
+            classifications=self.classifications,
+            fatwas=self.fatwas,
+        )
+        service.ensure_request(event_id)
+        if scenario.fatwa is not None:
+            self._apply_fatwa(event_id, scenario.fatwa)
+
+    def _seed_faq(self, approval: ReplayFAQApproval) -> None:
+        active = self.faqs.get_active(approval.faq_key)
+        if active is None:
+            self.faqs.create_version(
+                faq_key=approval.faq_key,
+                answer_text=approval.answer_text,
+                source_ref=approval.source_ref,
+                approved_by=approval.approved_by,
+                approved_at=approval.approved_at,
+            )
+            return
+        if (
+            active.answer_text != approval.answer_text
+            or active.source_ref != approval.source_ref
+            or active.approved_by != approval.approved_by
+            or active.approved_at != approval.approved_at
+        ):
+            raise ReplayEvidenceConflict("active FAQ approval differs from replay evidence")
+
+    def _apply_supervisor(
+        self,
+        event_id: str,
+        evidence: ReplaySupervisorEvidence,
+    ) -> None:
+        service = SupervisorService(
+            events=self.events,
+            classifications=self.classifications,
+            faqs=self.faqs,
+            supervisors=self.supervisors,
+        )
+        service.mark_dispatched(
+            event_id,
+            transport_name=evidence.transport_name,
+            external_thread_id=evidence.external_thread_id,
+        )
+        service.accept_response(
+            event_id,
+            external_response_key=evidence.external_response_key,
+            supervisor_ref=evidence.supervisor_ref,
+            text=evidence.text,
+            received_at=evidence.received_at,
+        )
+
+    def _apply_fatwa(self, event_id: str, evidence: ReplayFatwaEvidence) -> None:
+        service = FatwaService(
+            events=self.events,
+            classifications=self.classifications,
+            fatwas=self.fatwas,
+        )
+        service.mark_dispatched(
+            event_id,
+            bridge_name=evidence.bridge_name,
+            external_case_id=evidence.external_case_id,
+        )
+        service.accept_result(
+            event_id,
+            external_result_key=evidence.external_result_key,
+            outcome=evidence.outcome,
+            answer_text=evidence.answer_text,
+            approved_by=evidence.approved_by,
+            source_ref=evidence.source_ref,
+            received_at=evidence.received_at,
+        )

--- a/app/sandbox/replay.py
+++ b/app/sandbox/replay.py
@@ -28,6 +28,7 @@ from app.domain.publishing import (
     PublicationStatus,
 )
 from app.domain.shadow import ShadowOutcome
+from app.ingress.common import ExactIngestionCollector
 from app.persistence.classification_repository import ClassificationRepository
 from app.persistence.faq_repository import FAQRepository
 from app.persistence.fatwa_repository import FatwaRepository
@@ -47,7 +48,6 @@ from app.services.moderation_policy import ModerationPolicy
 from app.services.publishing import PublishingNotEligible, PublishingService
 from app.services.shadow import ShadowService
 from app.services.supervisor import SupervisorService
-from app.ingress.common import ExactIngestionCollector
 
 
 class ReplayEvidenceConflict(RuntimeError):
@@ -190,7 +190,7 @@ class _RecordingPublisher:
             )
         )
         identity = hashlib.sha256(
-            f"{self.platform.value}\0{external_comment_id}".encode("utf-8")
+            f"{self.platform.value}\0{external_comment_id}".encode()
         ).hexdigest()[:24]
         return f"sandbox-{identity}"
 
@@ -219,17 +219,12 @@ class SandboxReplayRuntime:
         self.classification_policy = ClassificationPolicy(minimum_faq_confidence=0.80)
         self.fatwa_policy = fatwa_policy
         self.evaluator_version = evaluator_version
-        self._publishers = {
-            platform: _RecordingPublisher(platform)
-            for platform in Platform
-        }
+        self._publishers = {platform: _RecordingPublisher(platform) for platform in Platform}
 
     @property
     def recorded_calls(self) -> tuple[RecordedPublishCall, ...]:
         return tuple(
-            call
-            for platform in Platform
-            for call in self._publishers[platform].calls
+            call for platform in Platform for call in self._publishers[platform].calls
         )
 
     async def replay(self, scenarios: Iterable[ReplayScenario]) -> ReplayReport:

--- a/docs/PHASE14_END_TO_END_SANDBOX.md
+++ b/docs/PHASE14_END_TO_END_SANDBOX.md
@@ -1,0 +1,96 @@
+# Phase 14 — End-to-End Sandbox Assembly & Replay Validation
+
+## Verdict
+
+**PASS — non-production replay/runtime boundary.**
+
+Production activation remains outside this phase.
+
+## What was composed
+
+`SandboxReplayRuntime` wires the existing durable V1 components over one SQLite database:
+
+1. exact/idempotent inbound ingestion;
+2. moderation and local moderation policy;
+3. classification only after `ALLOW_ROUTING`;
+4. approved FAQ resolution;
+5. human-supervisor evidence;
+6. supervised FATWA bridge evidence;
+7. side-effect-free Shadow evaluation;
+8. durable publishing with recording-only fake publishers.
+
+No live provider client is injected into this runtime.
+
+## Replay integrity
+
+The runtime compares replay evidence to already durable moderation/classification evidence. A replay that changes previously durable semantics raises `ReplayEvidenceConflict` instead of silently adopting new evidence.
+
+FAQ seed evidence is also stable: an existing active FAQ must match answer text, source reference, approver, and approval time exactly or replay fails closed.
+
+Wrong-route downstream evidence is rejected. Non-`ALLOW_ROUTING` moderation cannot be supplemented with FAQ, supervisor, or FATWA evidence.
+
+## External-side-effect containment
+
+The sandbox publisher stores only:
+
+- platform;
+- target identity used by the local replay;
+- SHA-256 of the candidate reply text;
+- text length.
+
+It does not retain the reply text and performs no HTTP/network operation. The replay report itself contains only platform/route/outcome counts and booleans/enums; it contains no user message or reply text.
+
+## FATWA invariant
+
+The default `FatwaPublicationPolicy.TELEGRAM_ONLY` remains authoritative. Even an approved external FATWA result is not dispatched to the originating comment under the default policy. A dedicated sandbox test may instantiate `ORIGIN_ONLY` only to verify that, when explicitly allowed in the sandbox, the exact externally approved answer fingerprint is used; no answer is generated or rewritten by Gheras.
+
+## Restart and idempotency proof
+
+The suite reopens `SandboxReplayRuntime` on the same SQLite file and replays the same scenario. The durable inbound event and succeeded outbound action are reused and the fresh recording publisher is not called. Same-process duplicate replay likewise creates neither a second event nor a second outbound action/provider call.
+
+## Four-platform matrix
+
+The end-to-end FAQ matrix executes Facebook, Instagram, Telegram, and YouTube scenarios. Each reaches publication only through active approved FAQ evidence and records the SHA-256 fingerprint of the exact approved answer.
+
+Additional scenarios verify:
+
+- supervisor route with accepted human response;
+- supervisor route without human response remains waiting;
+- low-confidence FAQ routes to supervisor;
+- moderation human-review prevents classification and outbound work;
+- approved FATWA remains origin-blocked by default;
+- durable moderation/classification drift fails closed;
+- changed FAQ approval fails closed;
+- wrong-route evidence fails closed;
+- replay report remains content-free.
+
+## Validation
+
+Implementation head before this documentation commit: `b124f290f37ff2ee8536a8e0e2635b65b104e04e`.
+
+GitHub Actions run `34482420462`:
+
+- Ruff: PASS
+- Mypy: PASS
+- Pytest: PASS
+
+## Adversarial review
+
+In-project adversarial review: **PASS** for the sandbox boundary.
+
+Review focus:
+
+- no live-network/provider dependency in `app/sandbox/replay.py`;
+- persist-first ordering is retained;
+- moderation gate precedes classification;
+- religious-possible classification still reaches FATWA;
+- FAQ/supervisor/FATWA text sources remain exact durable evidence;
+- Shadow/publishing disagreement fails closed;
+- duplicate and restart replays do not duplicate publication;
+- report data does not contain raw user/reply text.
+
+This review is not an independent external review. Independent review remains required before promotion to `main`.
+
+## External gate still excluded
+
+No production credential, OAuth grant, webhook registration, live provider call, live moderation/classification model call, or real publication was performed in Phase 14.

--- a/tests/test_end_to_end_sandbox.py
+++ b/tests/test_end_to_end_sandbox.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.classification import ClassificationAssessment, ClassificationRoute
+from app.domain.events import NormalizedInboundEvent, Platform
+from app.domain.fatwa import FatwaResultOutcome
+from app.domain.moderation import (
+    ModerationAssessment,
+    ModerationDisposition,
+    ModerationSeverity,
+    ModerationVerdict,
+)
+from app.domain.publishing import (
+    FatwaPublicationPolicy,
+    PublicationSourceKind,
+    PublicationStatus,
+)
+from app.domain.shadow import ShadowOutcome
+from app.sandbox.replay import (
+    ReplayEvidenceConflict,
+    ReplayFAQApproval,
+    ReplayFatwaEvidence,
+    ReplayScenario,
+    ReplaySupervisorEvidence,
+    SandboxReplayRuntime,
+)
+
+NOW = datetime(2026, 9, 10, 13, 0, tzinfo=UTC)
+FAQ_TEXT = "الإجابة المعتمدة حرفيًا من قاعدة الأسئلة الشائعة."
+SUPERVISOR_TEXT = "الإجابة البشرية المعتمدة حرفيًا."
+FATWA_TEXT = "جواب الجهة الشرعية المعتمد حرفيًا دون تعديل."
+
+
+def _run(coro: object) -> object:
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def _safe_moderation(*, confidence: float = 0.99) -> ModerationAssessment:
+    return ModerationAssessment(
+        verdict=ModerationVerdict.SAFE,
+        severity=ModerationSeverity.NONE,
+        confidence=confidence,
+        text_assessed=True,
+    )
+
+
+def _faq_classification(
+    *,
+    confidence: float = 0.99,
+    religious_possible: bool = False,
+) -> ClassificationAssessment:
+    return ClassificationAssessment(
+        proposed_route=ClassificationRoute.FAQ,
+        confidence=confidence,
+        religious_possible=religious_possible,
+        faq_key="registration.status",
+    )
+
+
+def _faq_approval(*, answer: str = FAQ_TEXT) -> ReplayFAQApproval:
+    return ReplayFAQApproval(
+        faq_key="registration.status",
+        answer_text=answer,
+        source_ref="sandbox://approved-faq/registration.status/v1",
+        approved_by="sandbox-reviewer",
+        approved_at=NOW,
+    )
+
+
+def _event(platform: Platform, *, suffix: str, text: str = "متى يبدأ التسجيل؟") -> NormalizedInboundEvent:
+    target = {
+        Platform.FACEBOOK: f"fb-comment-{suffix}",
+        Platform.INSTAGRAM: f"ig-comment-{suffix}",
+        Platform.TELEGRAM: f"-100777:{suffix}",
+        Platform.YOUTUBE: f"yt-comment-{suffix}",
+    }[platform]
+    return NormalizedInboundEvent(
+        platform=platform,
+        external_event_key=f"{platform.value}-event-{suffix}",
+        external_comment_id=target,
+        external_post_id=f"{platform.value}-post-{suffix}",
+        author_id=f"{platform.value}-author-{suffix}",
+        text=text,
+    )
+
+
+def _faq_scenario(platform: Platform, *, suffix: str) -> ReplayScenario:
+    return ReplayScenario(
+        event=_event(platform, suffix=suffix),
+        moderation=_safe_moderation(),
+        classification=_faq_classification(),
+        faq_approval=_faq_approval(),
+    )
+
+
+@pytest.mark.parametrize("platform", list(Platform))
+def test_four_platform_faq_matrix_publishes_only_approved_exact_text_fingerprint(
+    tmp_path: Path,
+    platform: Platform,
+) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / f"{platform.value}.db")
+    result = _run(runtime.replay_one(_faq_scenario(platform, suffix="1")))
+
+    assert result.platform is platform  # type: ignore[union-attr]
+    assert result.created_event is True  # type: ignore[union-attr]
+    assert result.moderation_disposition is ModerationDisposition.ALLOW_ROUTING  # type: ignore[union-attr]
+    assert result.route is ClassificationRoute.FAQ  # type: ignore[union-attr]
+    assert result.shadow_outcome is ShadowOutcome.WOULD_PUBLISH  # type: ignore[union-attr]
+    assert result.source_kind is PublicationSourceKind.FAQ  # type: ignore[union-attr]
+    assert result.publication_status is PublicationStatus.SUCCEEDED  # type: ignore[union-attr]
+    assert result.provider_called is True  # type: ignore[union-attr]
+
+    calls = runtime.recorded_calls
+    assert len(calls) == 1
+    assert calls[0].platform is platform
+    assert calls[0].text_sha256 == hashlib.sha256(FAQ_TEXT.encode("utf-8")).hexdigest()
+    assert calls[0].text_length == len(FAQ_TEXT)
+
+
+def test_supervisor_route_requires_and_publishes_exact_human_response_fingerprint(
+    tmp_path: Path,
+) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.TELEGRAM, suffix="55", text="أحتاج مساعدة بشرية"),
+        moderation=_safe_moderation(),
+        classification=ClassificationAssessment(
+            proposed_route=ClassificationRoute.SUPERVISOR,
+            confidence=0.99,
+            religious_possible=False,
+        ),
+        supervisor=ReplaySupervisorEvidence(
+            transport_name="telegram",
+            external_thread_id="sandbox-thread-55",
+            external_response_key="sandbox-response-55",
+            supervisor_ref="supervisor-1",
+            text=SUPERVISOR_TEXT,
+            received_at=NOW,
+        ),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.route is ClassificationRoute.SUPERVISOR  # type: ignore[union-attr]
+    assert result.shadow_outcome is ShadowOutcome.WOULD_PUBLISH  # type: ignore[union-attr]
+    assert result.source_kind is PublicationSourceKind.SUPERVISOR  # type: ignore[union-attr]
+    assert result.provider_called is True  # type: ignore[union-attr]
+    assert runtime.recorded_calls[0].text_sha256 == hashlib.sha256(
+        SUPERVISOR_TEXT.encode("utf-8")
+    ).hexdigest()
+
+
+def test_supervisor_route_without_human_response_waits_and_creates_no_outbound_action(
+    tmp_path: Path,
+) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.INSTAGRAM, suffix="2"),
+        moderation=_safe_moderation(),
+        classification=ClassificationAssessment(
+            proposed_route=ClassificationRoute.SUPERVISOR,
+            confidence=0.99,
+            religious_possible=False,
+        ),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.shadow_outcome is ShadowOutcome.WOULD_WAIT_HUMAN  # type: ignore[union-attr]
+    assert result.publication_status is None  # type: ignore[union-attr]
+    assert result.provider_called is False  # type: ignore[union-attr]
+    assert runtime.publications.count_actions() == 0
+    assert runtime.recorded_calls == ()
+
+
+def test_approved_fatwa_stays_origin_blocked_under_default_policy(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.FACEBOOK, suffix="fatwa", text="ما حكم هذه المسألة؟"),
+        moderation=_safe_moderation(),
+        classification=_faq_classification(religious_possible=True),
+        fatwa=ReplayFatwaEvidence(
+            bridge_name="sandbox-fatwa-bridge",
+            external_case_id="case-fatwa-1",
+            external_result_key="result-fatwa-1",
+            outcome=FatwaResultOutcome.APPROVED,
+            answer_text=FATWA_TEXT,
+            approved_by="scholar-reviewer",
+            source_ref="sandbox://fatwa/result/1",
+            received_at=NOW,
+        ),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.route is ClassificationRoute.FATWA  # type: ignore[union-attr]
+    assert result.shadow_outcome is ShadowOutcome.WOULD_ROUTE_FATWA  # type: ignore[union-attr]
+    assert result.publication_status is None  # type: ignore[union-attr]
+    assert result.provider_called is False  # type: ignore[union-attr]
+    assert runtime.recorded_calls == ()
+    assert runtime.publications.count_actions() == 0
+
+
+def test_explicit_sandbox_origin_fatwa_policy_uses_only_approved_external_fingerprint(
+    tmp_path: Path,
+) -> None:
+    runtime = SandboxReplayRuntime(
+        tmp_path / "router.db",
+        fatwa_policy=FatwaPublicationPolicy.ORIGIN_ONLY,
+    )
+    scenario = ReplayScenario(
+        event=_event(Platform.YOUTUBE, suffix="fatwa", text="سؤال شرعي"),
+        moderation=_safe_moderation(),
+        classification=ClassificationAssessment(
+            proposed_route=ClassificationRoute.FATWA,
+            confidence=0.99,
+            religious_possible=True,
+        ),
+        fatwa=ReplayFatwaEvidence(
+            bridge_name="sandbox-fatwa-bridge",
+            external_case_id="case-fatwa-2",
+            external_result_key="result-fatwa-2",
+            outcome=FatwaResultOutcome.APPROVED,
+            answer_text=FATWA_TEXT,
+            approved_by="scholar-reviewer",
+            source_ref="sandbox://fatwa/result/2",
+            received_at=NOW,
+        ),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.shadow_outcome is ShadowOutcome.WOULD_PUBLISH  # type: ignore[union-attr]
+    assert result.source_kind is PublicationSourceKind.FATWA  # type: ignore[union-attr]
+    assert runtime.recorded_calls[0].text_sha256 == hashlib.sha256(
+        FATWA_TEXT.encode("utf-8")
+    ).hexdigest()
+
+
+def test_moderation_human_review_stops_classification_and_all_outbound_work(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.YOUTUBE, suffix="low-mod"),
+        moderation=_safe_moderation(confidence=0.20),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.moderation_disposition is ModerationDisposition.HUMAN_REVIEW  # type: ignore[union-attr]
+    assert result.route is None  # type: ignore[union-attr]
+    assert result.shadow_outcome is ShadowOutcome.WOULD_WAIT_HUMAN  # type: ignore[union-attr]
+    assert runtime.classifications.count_results() == 0
+    assert runtime.publications.count_actions() == 0
+    assert runtime.recorded_calls == ()
+
+
+def test_low_confidence_faq_is_deterministically_routed_to_supervisor(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.FACEBOOK, suffix="low-class"),
+        moderation=_safe_moderation(),
+        classification=_faq_classification(confidence=0.20),
+    )
+
+    result = _run(runtime.replay_one(scenario))
+
+    assert result.route is ClassificationRoute.SUPERVISOR  # type: ignore[union-attr]
+    assert result.shadow_outcome is ShadowOutcome.WOULD_WAIT_HUMAN  # type: ignore[union-attr]
+    assert runtime.publications.count_actions() == 0
+
+
+def test_duplicate_replay_converges_without_duplicate_event_action_or_provider_call(
+    tmp_path: Path,
+) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = _faq_scenario(Platform.FACEBOOK, suffix="dup")
+
+    first = _run(runtime.replay_one(scenario))
+    second = _run(runtime.replay_one(scenario))
+
+    assert first.created_event is True  # type: ignore[union-attr]
+    assert first.provider_called is True  # type: ignore[union-attr]
+    assert second.created_event is False  # type: ignore[union-attr]
+    assert second.provider_called is False  # type: ignore[union-attr]
+    assert runtime.events.count_events() == 1
+    assert runtime.publications.count_actions() == 1
+    assert len(runtime.recorded_calls) == 1
+
+
+def test_restart_replay_preserves_event_and_publication_idempotency(tmp_path: Path) -> None:
+    database_path = tmp_path / "router.db"
+    scenario = _faq_scenario(Platform.TELEGRAM, suffix="restart")
+
+    first_runtime = SandboxReplayRuntime(database_path)
+    first = _run(first_runtime.replay_one(scenario))
+    assert first.provider_called is True  # type: ignore[union-attr]
+
+    restarted = SandboxReplayRuntime(database_path)
+    second = _run(restarted.replay_one(scenario))
+
+    assert second.created_event is False  # type: ignore[union-attr]
+    assert second.provider_called is False  # type: ignore[union-attr]
+    assert restarted.events.count_events() == 1
+    assert restarted.publications.count_actions() == 1
+    assert restarted.recorded_calls == ()
+
+
+def test_replay_rejects_changed_moderation_or_classification_evidence(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = _faq_scenario(Platform.INSTAGRAM, suffix="drift")
+    _run(runtime.replay_one(scenario))
+
+    changed_moderation = replace(
+        scenario,
+        moderation=_safe_moderation(confidence=0.95),
+    )
+    with pytest.raises(ReplayEvidenceConflict, match="moderation"):
+        _run(runtime.replay_one(changed_moderation))
+
+    changed_classification = replace(
+        scenario,
+        classification=_faq_classification(confidence=0.95),
+    )
+    with pytest.raises(ReplayEvidenceConflict, match="classification"):
+        _run(runtime.replay_one(changed_classification))
+
+
+def test_replay_rejects_changed_active_faq_approval(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = _faq_scenario(Platform.FACEBOOK, suffix="faq-drift")
+    _run(runtime.replay_one(scenario))
+
+    changed = replace(
+        scenario,
+        faq_approval=_faq_approval(answer="نص مختلف غير معتمد في التشغيل الأول"),
+    )
+    with pytest.raises(ReplayEvidenceConflict, match="FAQ approval"):
+        _run(runtime.replay_one(changed))
+
+
+def test_wrong_route_downstream_evidence_fails_closed(tmp_path: Path) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenario = ReplayScenario(
+        event=_event(Platform.TELEGRAM, suffix="wrong-evidence"),
+        moderation=_safe_moderation(),
+        classification=ClassificationAssessment(
+            proposed_route=ClassificationRoute.SUPERVISOR,
+            confidence=0.99,
+            religious_possible=False,
+        ),
+        faq_approval=_faq_approval(),
+    )
+
+    with pytest.raises(ReplayEvidenceConflict, match="SUPERVISOR route"):
+        _run(runtime.replay_one(scenario))
+
+
+def test_replay_report_is_content_free_and_aggregates_four_platform_matrix(
+    tmp_path: Path,
+) -> None:
+    runtime = SandboxReplayRuntime(tmp_path / "router.db")
+    scenarios = tuple(
+        _faq_scenario(platform, suffix=f"report-{index}")
+        for index, platform in enumerate(Platform, start=1)
+    )
+
+    report = _run(runtime.replay(scenarios))
+    rendered = repr(report)
+
+    assert report.provider_call_count == 4  # type: ignore[union-attr]
+    assert report.by_platform == {  # type: ignore[union-attr]
+        "facebook": 1,
+        "instagram": 1,
+        "telegram": 1,
+        "youtube": 1,
+    }
+    assert report.by_route == {"FAQ": 4}  # type: ignore[union-attr]
+    assert report.by_shadow_outcome == {"would_publish": 4}  # type: ignore[union-attr]
+    assert FAQ_TEXT not in rendered
+    assert SUPERVISOR_TEXT not in rendered
+    assert FATWA_TEXT not in rendered

--- a/tests/test_end_to_end_sandbox.py
+++ b/tests/test_end_to_end_sandbox.py
@@ -74,7 +74,12 @@ def _faq_approval(*, answer: str = FAQ_TEXT) -> ReplayFAQApproval:
     )
 
 
-def _event(platform: Platform, *, suffix: str, text: str = "متى يبدأ التسجيل؟") -> NormalizedInboundEvent:
+def _event(
+    platform: Platform,
+    *,
+    suffix: str,
+    text: str = "متى يبدأ التسجيل؟",
+) -> NormalizedInboundEvent:
     target = {
         Platform.FACEBOOK: f"fb-comment-{suffix}",
         Platform.INSTAGRAM: f"ig-comment-{suffix}",


### PR DESCRIPTION
## Summary

Closes Issue #32 as a stacked non-production change above the locked Phase 13 head.

### End-to-end sandbox runtime
- composes durable ingestion, moderation, classification, FAQ, supervisor, FATWA, shadow evaluation, and publishing over SQLite;
- uses recording-only publishers with no provider HTTP calls;
- records content fingerprints/lengths instead of retaining replay reply text in publisher call evidence;
- preserves exact approved FAQ, human supervisor, and externally approved FATWA source semantics.

### Replay safety
- exact duplicate replay converges without duplicate durable inbound events or outbound actions;
- restart replay against the same SQLite database converges;
- changed moderation/classification/approval evidence raises fail-closed replay conflicts rather than silently accepting semantic drift;
- blocked or human-review moderation cannot accept downstream routing evidence;
- shadow `would_publish` must agree with publishing eligibility.

### Four-platform matrix
- Facebook
- Instagram
- Telegram
- YouTube

The matrix covers FAQ publication, supervisor human-response behavior, FATWA default-policy blocking, low-confidence supervisor routing, duplicate/restart behavior, evidence-drift rejection, and content-free aggregate reporting.

### Validation
Final GitHub Actions run `34482658212` on head `5c3b216f6b7c89854d7d459f9adcdf212d442ca3`:
- Ruff PASS
- Mypy PASS
- Pytest PASS

No production credential, webhook registration, OAuth grant, external provider call, or real publication was performed.

In-project adversarial review is documented but does not substitute for independent review. Promotion to `main` remains blocked pending independent review and the stacked promotion chain.