### PR TITLE
Phase 18 — Production Operations, Recovery & Reconciliation Readiness

### DIFF
--- a/app/domain/reconciliation.py
+++ b/app/domain/reconciliation.py
@@ -1,0 +1,31 @@
+"""Domain records for explicit operator reconciliation of uncertain publication outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from app.domain.publishing import PublicationStatus
+
+
+class PublicationReconciliationDecision(StrEnum):
+    """Only provider-verified outcomes an operator may record."""
+
+    CONFIRMED_SUCCEEDED = "confirmed_succeeded"
+    CONFIRMED_NOT_SENT = "confirmed_not_sent"
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationReconciliationRecord:
+    """Immutable evidence for one manual publication reconciliation decision."""
+
+    id: str
+    action_id: str
+    prior_status: PublicationStatus
+    decision: PublicationReconciliationDecision
+    operator_ref: str
+    evidence_ref: str
+    external_reconciliation_key: str
+    external_result_id: str | None
+    created_at: datetime

--- a/app/operations/__init__.py
+++ b/app/operations/__init__.py
@@ -1,0 +1,1 @@
+"""Content-free production-operations support for Gheras."""

--- a/app/operations/database.py
+++ b/app/operations/database.py
@@ -74,10 +74,9 @@ def create_verified_backup(
     target_path.parent.mkdir(parents=True, exist_ok=True)
     created = False
     try:
-        with database.connect_readonly() as source:
-            with sqlite3.connect(target_path) as target:
-                created = True
-                source.backup(target)
+        with database.connect_readonly() as source, sqlite3.connect(target_path) as target:
+            created = True
+            source.backup(target)
 
         integrity = inspect_database(SQLiteDatabase(target_path))
         if not integrity.acceptable:

--- a/app/operations/database.py
+++ b/app/operations/database.py
@@ -1,0 +1,96 @@
+"""Safe SQLite integrity inspection and verified backup operations."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.persistence.sqlite import SQLiteDatabase
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseIntegrityReport:
+    """Content-free integrity result for one SQLite database file."""
+
+    integrity_ok: bool
+    foreign_key_violations: int
+
+    @property
+    def acceptable(self) -> bool:
+        return self.integrity_ok and self.foreign_key_violations == 0
+
+
+@dataclass(frozen=True, slots=True)
+class BackupReceipt:
+    """Evidence for one newly created and verified SQLite backup."""
+
+    destination: Path
+    size_bytes: int
+    sha256: str
+    created_at: datetime
+    integrity: DatabaseIntegrityReport
+
+
+def inspect_database(database: SQLiteDatabase) -> DatabaseIntegrityReport:
+    """Inspect an existing SQLite database without creating or modifying it."""
+
+    with database.connect_readonly() as connection:
+        integrity_rows = connection.execute("PRAGMA integrity_check").fetchall()
+        integrity_ok = bool(integrity_rows) and all(
+            str(row[0]).strip().lower() == "ok" for row in integrity_rows
+        )
+        foreign_key_violations = sum(
+            1 for _ in connection.execute("PRAGMA foreign_key_check")
+        )
+    return DatabaseIntegrityReport(
+        integrity_ok=integrity_ok,
+        foreign_key_violations=foreign_key_violations,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_verified_backup(
+    database: SQLiteDatabase,
+    destination: str | Path,
+) -> BackupReceipt:
+    """Create one consistent backup, refusing implicit overwrite and validating the result."""
+
+    target_path = Path(destination)
+    if target_path.exists():
+        raise FileExistsError(target_path)
+    if not database.path.is_file():
+        raise FileNotFoundError(database.path)
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    created = False
+    try:
+        with database.connect_readonly() as source:
+            with sqlite3.connect(target_path) as target:
+                created = True
+                source.backup(target)
+
+        integrity = inspect_database(SQLiteDatabase(target_path))
+        if not integrity.acceptable:
+            raise RuntimeError("backup failed SQLite integrity verification")
+
+        return BackupReceipt(
+            destination=target_path,
+            size_bytes=target_path.stat().st_size,
+            sha256=_sha256_file(target_path),
+            created_at=datetime.now(UTC),
+            integrity=integrity,
+        )
+    except Exception:
+        if created and target_path.exists():
+            target_path.unlink()
+        raise

--- a/app/operations/readiness.py
+++ b/app/operations/readiness.py
@@ -1,0 +1,178 @@
+"""Content-free operational readiness and reconciliation visibility."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+
+from app.domain.events import Platform
+from app.domain.publishing import PublicationStatus
+from app.operations.database import DatabaseIntegrityReport, inspect_database
+from app.persistence.sqlite import SQLiteDatabase
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalSnapshot:
+    """Counts-only operational state suitable for health/readiness surfaces."""
+
+    integrity: DatabaseIntegrityReport
+    inbound_total: int
+    inbound_received: int
+    inbound_processing: int
+    inbound_waiting_human: int
+    inbound_failed_retryable: int
+    inbound_failed_terminal: int
+    pending_moderation_reviews: int
+    supervisor_pending_dispatch: int
+    supervisor_awaiting_response: int
+    fatwa_pending_dispatch: int
+    fatwa_awaiting_result: int
+    publications_pending: int
+    publications_dispatching: int
+    publications_uncertain: int
+    publications_succeeded: int
+    shadow_total: int
+
+    @property
+    def requires_operator_attention(self) -> bool:
+        return bool(
+            not self.integrity.acceptable
+            or self.publications_dispatching
+            or self.publications_uncertain
+            or self.inbound_failed_terminal
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationReconciliationItem:
+    """Opaque publication hold requiring operator/provider-side reconciliation."""
+
+    action_id: str
+    platform: Platform
+    status: PublicationStatus
+    updated_at: datetime
+
+
+class OperationalReadinessService:
+    """Read-only operational queries; this service never retries or mutates work."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    @staticmethod
+    def _count(
+        connection: sqlite3.Connection,
+        query: str,
+        parameters: tuple[object, ...] = (),
+    ) -> int:
+        row = connection.execute(query, parameters).fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def snapshot(self) -> OperationalSnapshot:
+        """Return counts and integrity only; no inbound/reply text is selected."""
+
+        integrity = inspect_database(self.database)
+        with self.database.connect_readonly() as connection:
+            count = self._count
+            return OperationalSnapshot(
+                integrity=integrity,
+                inbound_total=count(connection, "SELECT COUNT(*) FROM inbound_events"),
+                inbound_received=count(
+                    connection,
+                    "SELECT COUNT(*) FROM inbound_events WHERE status = ?",
+                    ("received",),
+                ),
+                inbound_processing=count(
+                    connection,
+                    "SELECT COUNT(*) FROM inbound_events WHERE status = ?",
+                    ("processing",),
+                ),
+                inbound_waiting_human=count(
+                    connection,
+                    "SELECT COUNT(*) FROM inbound_events WHERE status = ?",
+                    ("waiting_human",),
+                ),
+                inbound_failed_retryable=count(
+                    connection,
+                    "SELECT COUNT(*) FROM inbound_events WHERE status = ?",
+                    ("failed_retryable",),
+                ),
+                inbound_failed_terminal=count(
+                    connection,
+                    "SELECT COUNT(*) FROM inbound_events WHERE status = ?",
+                    ("failed_terminal",),
+                ),
+                pending_moderation_reviews=count(
+                    connection,
+                    "SELECT COUNT(*) FROM moderation_human_reviews WHERE status = ?",
+                    ("pending",),
+                ),
+                supervisor_pending_dispatch=count(
+                    connection,
+                    "SELECT COUNT(*) FROM supervisor_escalations WHERE status = ?",
+                    ("pending_dispatch",),
+                ),
+                supervisor_awaiting_response=count(
+                    connection,
+                    "SELECT COUNT(*) FROM supervisor_escalations WHERE status = ?",
+                    ("awaiting_response",),
+                ),
+                fatwa_pending_dispatch=count(
+                    connection,
+                    "SELECT COUNT(*) FROM fatwa_bridge_requests WHERE status = ?",
+                    ("pending_dispatch",),
+                ),
+                fatwa_awaiting_result=count(
+                    connection,
+                    "SELECT COUNT(*) FROM fatwa_bridge_requests WHERE status = ?",
+                    ("awaiting_result",),
+                ),
+                publications_pending=count(
+                    connection,
+                    "SELECT COUNT(*) FROM outbound_actions WHERE status = ?",
+                    (PublicationStatus.PENDING.value,),
+                ),
+                publications_dispatching=count(
+                    connection,
+                    "SELECT COUNT(*) FROM outbound_actions WHERE status = ?",
+                    (PublicationStatus.DISPATCHING.value,),
+                ),
+                publications_uncertain=count(
+                    connection,
+                    "SELECT COUNT(*) FROM outbound_actions WHERE status = ?",
+                    (PublicationStatus.UNCERTAIN.value,),
+                ),
+                publications_succeeded=count(
+                    connection,
+                    "SELECT COUNT(*) FROM outbound_actions WHERE status = ?",
+                    (PublicationStatus.SUCCEEDED.value,),
+                ),
+                shadow_total=count(connection, "SELECT COUNT(*) FROM shadow_evaluations"),
+            )
+
+    def publication_reconciliation_items(self) -> tuple[PublicationReconciliationItem, ...]:
+        """List only opaque publication holds; never retry or expose source/reply text."""
+
+        with self.database.connect_readonly() as connection:
+            rows = connection.execute(
+                """
+                SELECT id, platform, status, updated_at
+                FROM outbound_actions
+                WHERE status IN (?, ?)
+                ORDER BY updated_at, id
+                """,
+                (
+                    PublicationStatus.DISPATCHING.value,
+                    PublicationStatus.UNCERTAIN.value,
+                ),
+            ).fetchall()
+        return tuple(
+            PublicationReconciliationItem(
+                action_id=str(row["id"]),
+                platform=Platform(str(row["platform"])),
+                status=PublicationStatus(str(row["status"])),
+                updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            )
+            for row in rows
+        )

--- a/app/persistence/operations_schema.py
+++ b/app/persistence/operations_schema.py
@@ -1,0 +1,37 @@
+"""Additive operational schema for durable publication reconciliation."""
+
+OPERATIONS_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS publication_reconciliations (
+    id TEXT PRIMARY KEY,
+    action_id TEXT NOT NULL,
+    prior_status TEXT NOT NULL CHECK (
+        prior_status IN ('dispatching', 'uncertain')
+    ),
+    decision TEXT NOT NULL CHECK (
+        decision IN ('confirmed_succeeded', 'confirmed_not_sent')
+    ),
+    operator_ref TEXT NOT NULL CHECK (length(trim(operator_ref)) > 0),
+    evidence_ref TEXT NOT NULL CHECK (length(trim(evidence_ref)) > 0),
+    external_reconciliation_key TEXT NOT NULL UNIQUE CHECK (
+        length(trim(external_reconciliation_key)) > 0
+    ),
+    external_result_id TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (action_id) REFERENCES outbound_actions(id) ON DELETE CASCADE,
+    CHECK (
+        (
+            decision = 'confirmed_succeeded'
+            AND external_result_id IS NOT NULL
+            AND length(trim(external_result_id)) > 0
+        )
+        OR
+        (
+            decision = 'confirmed_not_sent'
+            AND external_result_id IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_publication_reconciliations_action
+ON publication_reconciliations (action_id, created_at);
+"""

--- a/app/persistence/reconciliation_repository.py
+++ b/app/persistence/reconciliation_repository.py
@@ -1,0 +1,218 @@
+"""Atomic persistence for explicit publication reconciliation decisions."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.domain.events import OutboundAction, Platform
+from app.domain.publishing import PublicationStatus
+from app.domain.reconciliation import (
+    PublicationReconciliationDecision,
+    PublicationReconciliationRecord,
+)
+from app.persistence.repositories import IdempotencyConflict
+from app.persistence.sqlite import SQLiteDatabase
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _to_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat()
+
+
+def _from_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _required_text(value: str, *, field: str, maximum: int = 512) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    if len(normalized) > maximum:
+        raise ValueError(f"{field} exceeds maximum length")
+    return normalized
+
+
+def _compact_identifier(value: str, *, field: str, maximum: int = 512) -> str:
+    normalized = _required_text(value, field=field, maximum=maximum)
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field} must be a compact identifier")
+    return normalized
+
+
+def _action_from_row(row: sqlite3.Row) -> OutboundAction:
+    return OutboundAction(
+        id=str(row["id"]),
+        event_id=str(row["event_id"]),
+        platform=Platform(str(row["platform"])),
+        action_type=str(row["action_type"]),
+        idempotency_key=str(row["idempotency_key"]),
+        status=str(row["status"]),
+        external_result_id=(
+            str(row["external_result_id"])
+            if row["external_result_id"] is not None
+            else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+        updated_at=_from_timestamp(str(row["updated_at"])),
+    )
+
+
+def _record_from_row(row: sqlite3.Row) -> PublicationReconciliationRecord:
+    return PublicationReconciliationRecord(
+        id=str(row["id"]),
+        action_id=str(row["action_id"]),
+        prior_status=PublicationStatus(str(row["prior_status"])),
+        decision=PublicationReconciliationDecision(str(row["decision"])),
+        operator_ref=str(row["operator_ref"]),
+        evidence_ref=str(row["evidence_ref"]),
+        external_reconciliation_key=str(row["external_reconciliation_key"]),
+        external_result_id=(
+            str(row["external_result_id"])
+            if row["external_result_id"] is not None
+            else None
+        ),
+        created_at=_from_timestamp(str(row["created_at"])),
+    )
+
+
+class PublicationReconciliationRepository:
+    """Resolve publication holds only from explicit provider-verified evidence."""
+
+    def __init__(self, database: SQLiteDatabase) -> None:
+        self.database = database
+
+    def reconcile(
+        self,
+        *,
+        action_id: str,
+        decision: PublicationReconciliationDecision,
+        operator_ref: str,
+        evidence_ref: str,
+        external_reconciliation_key: str,
+        external_result_id: str | None = None,
+    ) -> tuple[PublicationReconciliationRecord, OutboundAction]:
+        """Record evidence and atomically move one held action to its verified state."""
+
+        safe_operator = _required_text(operator_ref, field="operator_ref")
+        safe_evidence = _required_text(evidence_ref, field="evidence_ref")
+        safe_key = _compact_identifier(
+            external_reconciliation_key,
+            field="external_reconciliation_key",
+            maximum=256,
+        )
+        safe_result: str | None = None
+        if decision is PublicationReconciliationDecision.CONFIRMED_SUCCEEDED:
+            if external_result_id is None:
+                raise ValueError("confirmed_succeeded requires external_result_id")
+            safe_result = _compact_identifier(
+                external_result_id,
+                field="external_result_id",
+            )
+        elif external_result_id is not None:
+            raise ValueError("confirmed_not_sent must not include external_result_id")
+
+        with self.database.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            existing_row = connection.execute(
+                """
+                SELECT * FROM publication_reconciliations
+                WHERE external_reconciliation_key = ?
+                """,
+                (safe_key,),
+            ).fetchone()
+            if existing_row is not None:
+                existing = _record_from_row(existing_row)
+                if (
+                    existing.action_id != action_id
+                    or existing.decision is not decision
+                    or existing.operator_ref != safe_operator
+                    or existing.evidence_ref != safe_evidence
+                    or existing.external_result_id != safe_result
+                ):
+                    connection.rollback()
+                    raise IdempotencyConflict(
+                        "reconciliation key is already bound to different semantics"
+                    )
+                action_row = connection.execute(
+                    "SELECT * FROM outbound_actions WHERE id = ?",
+                    (action_id,),
+                ).fetchone()
+                connection.commit()
+                if action_row is None:
+                    raise RuntimeError("reconciled outbound action could not be reloaded")
+                return existing, _action_from_row(action_row)
+
+            action_row = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            if action_row is None:
+                connection.rollback()
+                raise LookupError(action_id)
+            action = _action_from_row(action_row)
+            prior_status = PublicationStatus(action.status)
+            if prior_status not in {
+                PublicationStatus.DISPATCHING,
+                PublicationStatus.UNCERTAIN,
+            }:
+                connection.rollback()
+                raise ValueError("only dispatching or uncertain publication may be reconciled")
+
+            record_id = str(uuid4())
+            now = _utc_now()
+            connection.execute(
+                """
+                INSERT INTO publication_reconciliations (
+                    id, action_id, prior_status, decision, operator_ref,
+                    evidence_ref, external_reconciliation_key,
+                    external_result_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record_id,
+                    action_id,
+                    prior_status.value,
+                    decision.value,
+                    safe_operator,
+                    safe_evidence,
+                    safe_key,
+                    safe_result,
+                    _to_timestamp(now),
+                ),
+            )
+
+            if decision is PublicationReconciliationDecision.CONFIRMED_SUCCEEDED:
+                next_status = PublicationStatus.SUCCEEDED
+            else:
+                next_status = PublicationStatus.PENDING
+            connection.execute(
+                """
+                UPDATE outbound_actions
+                SET status = ?, external_result_id = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    next_status.value,
+                    safe_result,
+                    _to_timestamp(now),
+                    action_id,
+                ),
+            )
+            record_row = connection.execute(
+                "SELECT * FROM publication_reconciliations WHERE id = ?",
+                (record_id,),
+            ).fetchone()
+            updated_action_row = connection.execute(
+                "SELECT * FROM outbound_actions WHERE id = ?",
+                (action_id,),
+            ).fetchone()
+            connection.commit()
+
+        if record_row is None or updated_action_row is None:
+            raise RuntimeError("reconciliation transaction could not be reloaded")
+        return _record_from_row(record_row), _action_from_row(updated_action_row)

--- a/app/persistence/sqlite.py
+++ b/app/persistence/sqlite.py
@@ -43,6 +43,24 @@ class SQLiteDatabase:
         connection.execute("PRAGMA journal_mode = WAL")
         return connection
 
+    def connect_readonly(self) -> sqlite3.Connection:
+        """Open an existing database without creating or mutating it."""
+
+        if not self.path.is_file():
+            raise FileNotFoundError(self.path)
+        uri = f"{self.path.resolve().as_uri()}?mode=ro"
+        connection = sqlite3.connect(
+            uri,
+            uri=True,
+            timeout=self.busy_timeout_ms / 1000,
+            isolation_level=None,
+            check_same_thread=False,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(f"PRAGMA busy_timeout = {self.busy_timeout_ms}")
+        return connection
+
     def initialize(self) -> None:
         """Create the Phase 1 schema idempotently."""
 

--- a/app/persistence/sqlite.py
+++ b/app/persistence/sqlite.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from app.persistence.operations_schema import OPERATIONS_SCHEMA_SQL
 from app.persistence.schema import SCHEMA_SQL
 
 
@@ -62,7 +63,8 @@ class SQLiteDatabase:
         return connection
 
     def initialize(self) -> None:
-        """Create the Phase 1 schema idempotently."""
+        """Create the complete idempotent V1 schema, including operational extensions."""
 
         with self.connect() as connection:
             connection.executescript(SCHEMA_SQL)
+            connection.executescript(OPERATIONS_SCHEMA_SQL)

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -1,0 +1,55 @@
+"""Operator-facing service for provider-verified publication reconciliation."""
+
+from __future__ import annotations
+
+from app.domain.events import OutboundAction
+from app.domain.reconciliation import (
+    PublicationReconciliationDecision,
+    PublicationReconciliationRecord,
+)
+from app.persistence.reconciliation_repository import PublicationReconciliationRepository
+
+
+class PublicationReconciliationService:
+    """Expose only explicit verified outcomes; never infer or auto-retry publication."""
+
+    def __init__(self, repository: PublicationReconciliationRepository) -> None:
+        self.repository = repository
+
+    def confirm_succeeded(
+        self,
+        *,
+        action_id: str,
+        operator_ref: str,
+        evidence_ref: str,
+        external_reconciliation_key: str,
+        external_result_id: str,
+    ) -> tuple[PublicationReconciliationRecord, OutboundAction]:
+        """Record provider-confirmed success and close the held action as succeeded."""
+
+        return self.repository.reconcile(
+            action_id=action_id,
+            decision=PublicationReconciliationDecision.CONFIRMED_SUCCEEDED,
+            operator_ref=operator_ref,
+            evidence_ref=evidence_ref,
+            external_reconciliation_key=external_reconciliation_key,
+            external_result_id=external_result_id,
+        )
+
+    def confirm_not_sent(
+        self,
+        *,
+        action_id: str,
+        operator_ref: str,
+        evidence_ref: str,
+        external_reconciliation_key: str,
+    ) -> tuple[PublicationReconciliationRecord, OutboundAction]:
+        """Record verified non-delivery and return the action to pending for later dispatch."""
+
+        return self.repository.reconcile(
+            action_id=action_id,
+            decision=PublicationReconciliationDecision.CONFIRMED_NOT_SENT,
+            operator_ref=operator_ref,
+            evidence_ref=evidence_ref,
+            external_reconciliation_key=external_reconciliation_key,
+        )

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -74,7 +74,7 @@ Real sandbox credentials and provider-side validation remain a Human Gate becaus
 
 **Status:** NOT CONNECTED BY DESIGN
 
-The Phase 7 bridge remains a durable contract. No external FATWA runtime is called by Phases 11–17.
+The Phase 7 bridge remains a durable contract. No external FATWA runtime is called by Phases 11–18.
 
 The real connection requires authentication material, approved-result provenance verification, and failure/reconciliation validation in sandbox/staging before activation.
 
@@ -117,18 +117,34 @@ No production reply publishing is authorized during this gate.
 
 ## HG-10 — Production configuration and operations
 
-**Status:** REQUIRED / PREPARATION CONTINUES NON-LIVE
+**Status:** ENGINEERING PREPARATION PASS IN PHASE 18 / ENVIRONMENT-SPECIFIC ACTIVATION HOLD
 
-Before production activation, finalize:
+Phase 18 completes the non-live operational preparation layer:
 
-- deployment environment and database location/backup policy;
-- log retention and redaction policy;
-- operational ownership for `dispatching`/`uncertain` reconciliation;
-- monitoring and alerting;
-- webhook/network ingress controls;
-- rollback/cutover procedure.
+- a provider-neutral production operations/runbook and explicit activation checklist are defined;
+- read-only operational readiness reports counts/state only and does not select comment/reply text or secrets;
+- SQLite integrity and foreign-key checks are available without creating or mutating a missing database;
+- verified SQLite-native backup refuses implicit overwrite, verifies the new backup, and emits SHA-256 evidence;
+- publication `dispatching`/`uncertain` holds are visible through a content-free reconciliation inventory;
+- publication reconciliation is durable, idempotent, and atomic: provider-confirmed success closes an action as `succeeded`, while provider-confirmed non-delivery returns it to `pending` without publishing anything;
+- reconciliation requires explicit operator/evidence references and never performs a blind retry;
+- logging/redaction, monitoring classes, backup/restore, cutover, rollback, and incident priorities are documented;
+- local operational CLIs are provided for readiness, verified backup, and guarded reconciliation without provider calls.
 
-Non-live runbook and validation tooling may be prepared before these owner/environment decisions are made. Production activation remains blocked until the final environment-specific choices are reviewed.
+The following remain Human Gates because they depend on the actual deployment environment or external systems:
+
+- production OS/architecture and runtime/process topology;
+- persistent SQLite volume/filesystem selection and validation;
+- approved secret store and credential rotation ownership;
+- backup retention/access policy and a production-equivalent restore rehearsal;
+- monitoring destination, service targets, and alert thresholds;
+- TLS termination, public ingress, and network controls;
+- real provider sandbox validation and scopes;
+- supervised FATWA live integration;
+- staging Shadow acceptance;
+- explicit production publication activation.
+
+Production activation remains blocked until those environment-specific choices and rehearsals are completed. Phase 18 does not deploy or modify any live provider configuration.
 
 ## HG-11 — Merge/promotion to `main`
 

--- a/docs/PHASE18_PRODUCTION_OPERATIONS_LOCK.md
+++ b/docs/PHASE18_PRODUCTION_OPERATIONS_LOCK.md
@@ -1,0 +1,88 @@
+# Phase 18 — Production Operations & Recovery Lock
+
+**Status:** ENGINEERING PREPARATION PASS / LIVE ACTIVATION HOLD
+
+## Scope
+
+Phase 18 closes the non-live operational preparation layer above the locked Phase 17 supply-chain gate. It prepares local operational visibility, verified SQLite backup/integrity handling, durable publication reconciliation, and production runbooks without deploying Gheras or performing any provider-side action.
+
+## Locked engineering controls
+
+### Read-only readiness
+
+- `SQLiteDatabase.connect_readonly()` refuses a missing database and does not create it.
+- `OperationalReadinessService` selects counts/state only.
+- Readiness does not select inbound comment text, approved reply text, credentials, idempotency keys, or provider result identifiers.
+- Operator attention is raised for database-integrity failure, foreign-key violations, held publication states, or terminal inbound failures.
+
+### Verified SQLite backup
+
+- backup uses SQLite's backup API rather than copying a live WAL database file;
+- a missing source is refused;
+- an existing destination is refused rather than overwritten;
+- the new backup must pass SQLite integrity and foreign-key checks;
+- a newly created invalid backup is removed on failure;
+- successful backup evidence includes size, timestamp, and SHA-256.
+
+### Publication reconciliation
+
+- `dispatching` and `uncertain` actions remain fail-closed until provider-side outcome is verified;
+- reconciliation evidence is stored durably in `publication_reconciliations`;
+- each reconciliation records prior status, operator reference, evidence reference, external reconciliation key, decision, and provider result ID when success is confirmed;
+- external reconciliation keys are idempotent and conflicting semantics are rejected;
+- reconciliation and outbound-action state transition occur in one `BEGIN IMMEDIATE` transaction;
+- `confirmed_succeeded` moves the action to `succeeded` with a stable provider result ID;
+- `confirmed_not_sent` moves the action to `pending` but does not call a publisher;
+- unresolved provider outcome remains held; no inference and no blind retry are authorized.
+
+### Operational tools and procedures
+
+- `scripts/ops_readiness.py` prints content-free readiness JSON;
+- `scripts/ops_backup.py` creates one verified, non-overwriting backup;
+- `scripts/ops_reconcile_publication.py` requires explicit provider-outcome verification before recording a reconciliation decision;
+- `docs/PRODUCTION_OPERATIONS_RUNBOOK.md` defines backup/restore, redaction, monitoring, reconciliation, ingress, Shadow, cutover, rollback, and incident procedures;
+- `docs/PRODUCTION_ACTIVATION_CHECKLIST.md` keeps every environment-specific or external dependency as an explicit HOLD until verified.
+
+## Validation evidence
+
+Pre-lock full CI after implementation and lint remediation:
+
+- run: `34607277283`
+- branch: `phase/18-production-operations`
+- head: `269e8744f9a9af64dd43e6a49e83f3271e267a00`
+- production lock metadata: PASS
+- dependency consistency: PASS
+- production dependency audit: PASS
+- build-tool audit: PASS
+- CI/development audit: PASS
+- production environment reproduction: PASS
+- Ruff: PASS
+- Mypy: PASS
+- Pytest: PASS
+
+The documentation closure commits are followed by one final CI run before the branch is treated as locked.
+
+## Adversarial review result
+
+The Phase 17 → Phase 18 diff was inspected for scope expansion. The changes are limited to local SQLite operations, durable reconciliation, tests, local scripts, and operational documentation. No provider network client is invoked by the new operational layer, no credential is introduced, and no live publishing path is enabled.
+
+The reconciliation design deliberately separates provider-side verification from later publishing: a `confirmed_not_sent` decision only restores `pending` state. Any subsequent publication still requires the separate governed dispatcher.
+
+## Human Gates that remain
+
+Phase 18 does not select or validate the real production environment. The following remain HOLD:
+
+- production OS/architecture and target artifact/hash verification;
+- process topology and persistent SQLite filesystem/volume;
+- secret store, credentials, provider scopes, and rotation ownership;
+- real Facebook/Instagram/Telegram/YouTube sandbox validation;
+- supervised FATWA live integration and final publication policy decision;
+- production-equivalent backup/restore rehearsal;
+- monitoring destinations, service targets, and alert thresholds;
+- TLS/public ingress and network controls;
+- representative staging Shadow evaluation and acceptance;
+- independent submitted review of the stacked implementation chain;
+- reviewed promotion to `main`;
+- explicit production publication activation.
+
+No secret, credential, external provider call, webhook registration, OAuth exchange, deployment, AI-generated FATWA, or production publication is introduced by Phase 18.

--- a/docs/PRODUCTION_ACTIVATION_CHECKLIST.md
+++ b/docs/PRODUCTION_ACTIVATION_CHECKLIST.md
@@ -1,0 +1,135 @@
+# Gheras Social Router — Production Activation Checklist
+
+**Purpose:** final environment-specific gate before any live publishing is enabled.
+
+Every unresolved item is a HOLD. Completing this checklist is not implied by engineering CI alone.
+
+## A. Release identity
+
+- [ ] Exact release commit SHA recorded.
+- [ ] Relevant stacked PR chain has the required independent submitted review.
+- [ ] Final CI for the exact release SHA is PASS.
+- [ ] Point-in-time SCA is current for the exact release dependency lock.
+- [ ] Production OS/architecture selected and target artifact/hash verification completed.
+
+## B. Deployment environment
+
+- [ ] Production OS/runtime image approved.
+- [ ] Python 3.12 patch/runtime version recorded.
+- [ ] Persistent SQLite volume path approved.
+- [ ] Filesystem locking semantics validated for SQLite.
+- [ ] Authoritative write-process topology approved.
+- [ ] TLS/ingress/proxy ownership approved.
+- [ ] Health/readiness collection path approved.
+
+## C. Secrets and provider scopes
+
+Values must remain outside Git, chat, and tickets.
+
+- [ ] Meta access token provisioned in approved secret store.
+- [ ] Meta app secret provisioned.
+- [ ] Meta verify token provisioned.
+- [ ] Telegram bot token/webhook secret provisioned.
+- [ ] YouTube/Google credentials and required scopes provisioned.
+- [ ] Moderation/classification provider credential provisioned if used.
+- [ ] FATWA bridge authentication material provisioned.
+- [ ] Minimum provider scopes independently reviewed.
+- [ ] Rotation/revocation owner recorded.
+
+## D. Provider sandbox validation
+
+- [ ] Facebook ingress validation passed.
+- [ ] Instagram ingress validation passed.
+- [ ] Telegram ingress validation passed.
+- [ ] YouTube ingress/polling validation passed.
+- [ ] Webhook signature/secret failure cases verified.
+- [ ] Provider rate-limit behavior verified.
+- [ ] Token-expiry/authentication failure behavior verified.
+- [ ] No production publishing enabled during these tests.
+
+## E. FATWA integration
+
+- [ ] Supervised FATWA runtime connected in staging.
+- [ ] Authentication boundary verified.
+- [ ] Approved-result provenance verified.
+- [ ] Rejected/non-approved results cannot publish.
+- [ ] Failure/restart/reconciliation behavior verified.
+- [ ] Publication destination policy explicitly approved.
+- [ ] Default remains `telegram_only` unless a different policy is explicitly approved.
+
+## F. Database and recovery
+
+- [ ] Production-equivalent database initialized successfully.
+- [ ] SQLite integrity check PASS.
+- [ ] Foreign-key check PASS.
+- [ ] Backup destination/access policy approved.
+- [ ] Verified backup created successfully.
+- [ ] Backup SHA-256 recorded.
+- [ ] Restore rehearsal completed in staging.
+- [ ] Restore rehearsal includes post-restore reconciliation review.
+- [ ] Backup retention/deletion policy approved.
+
+## G. Monitoring and redaction
+
+- [ ] Logs contain no secrets.
+- [ ] Default logs do not contain full user comment/reply text.
+- [ ] Provider error sanitization verified.
+- [ ] Database-integrity alert configured.
+- [ ] `uncertain` publication alert configured.
+- [ ] stale `dispatching` alert threshold approved/configured.
+- [ ] terminal inbound failure alert configured.
+- [ ] supervisor/FATWA queue-age targets approved/configured.
+- [ ] backup verification failure alert configured.
+- [ ] authentication/signature failure monitoring configured.
+
+## H. Reconciliation readiness
+
+- [ ] Current `dispatching` count reviewed.
+- [ ] Current `uncertain` count reviewed.
+- [ ] Every held action has an owner.
+- [ ] No held action will be blindly retried.
+- [ ] Operator/provider evidence procedure rehearsed.
+- [ ] `confirmed_succeeded` path rehearsed.
+- [ ] `confirmed_not_sent` path rehearsed.
+- [ ] reconciliation idempotency behavior verified.
+
+## I. Staging Shadow gate
+
+- [ ] Representative staging/replay dataset defined.
+- [ ] Evaluator version recorded.
+- [ ] Shadow run performed with publishing disabled.
+- [ ] `would_publish` distribution reviewed.
+- [ ] `would_wait_human` distribution reviewed.
+- [ ] `would_route_fatwa` distribution reviewed.
+- [ ] `not_ready` cases reviewed.
+- [ ] `blocked` cases reviewed.
+- [ ] Unexpected routing/moderation cases resolved or explicitly held.
+- [ ] Shadow acceptance recorded.
+
+## J. Cutover
+
+- [ ] Legacy path remains retired.
+- [ ] Pre-cutover verified backup completed.
+- [ ] Release SHA matches reviewed/tested artifact.
+- [ ] Secrets injected only through approved secret store.
+- [ ] Start in non-publishing/Shadow mode.
+- [ ] Readiness snapshot reviewed after startup.
+- [ ] Provider ingress verified after startup.
+- [ ] Supervisor/FATWA paths verified.
+- [ ] Explicit owner approval to enable production publication recorded.
+
+## K. Rollback
+
+- [ ] Publication-disable mechanism identified and tested.
+- [ ] Rollback release/artifact identified.
+- [ ] Database preservation procedure tested.
+- [ ] `dispatching`/`uncertain` inventory procedure tested.
+- [ ] Rollback does not blindly replay held actions.
+- [ ] Database restore path, if needed, is maintenance-mode only.
+- [ ] Return-to-Shadow procedure tested before re-enabling publication.
+
+## Final decision
+
+- [ ] **LIVE ACTIVATION APPROVED**
+
+Approval must identify the release SHA, environment, approver, timestamp, and any approved residual risks. Until that explicit record exists, live publication remains HOLD.

--- a/docs/PRODUCTION_OPERATIONS_RUNBOOK.md
+++ b/docs/PRODUCTION_OPERATIONS_RUNBOOK.md
@@ -1,0 +1,282 @@
+# Gheras Social Router — Production Operations Runbook
+
+**Mode:** PRE-LIVE PREPARATION
+
+This runbook defines the operational procedure for Gheras V1. It does not authorize production activation. Any step requiring live credentials, provider-side changes, deployment, DNS/network ingress, or publication remains behind the corresponding Human Gate.
+
+## 1. Non-negotiable invariants
+
+1. Gheras never generates, rewrites, summarizes, or translates FATWA content.
+2. Religious-possible content routes through the governed FATWA path.
+3. FAQ publication uses only an active approved FAQ entry.
+4. Supervisor publication uses only an accepted durable human response.
+5. FATWA publication uses only an externally approved attributed result and the configured destination policy.
+6. Machine moderation `HUMAN_REVIEW` never becomes routing permission without a durable human `allow_routing` decision.
+7. `dispatching` and `uncertain` outbound actions are never blindly retried.
+8. Secrets are never committed, pasted into tickets/chat, or written to application logs.
+9. Production promotion requires the relevant CI and independent-review gates.
+
+## 2. Deployment target decision — HOLD until selected
+
+Before production activation, record the target environment and approve:
+
+- operating system and CPU architecture;
+- Python 3.12 patch version/runtime image;
+- persistent volume location for SQLite;
+- process model: exactly one authoritative write-capable application deployment unless a separately validated SQLite coordination design exists;
+- ingress termination/proxy and TLS ownership;
+- backup destination and retention;
+- monitoring/alerting destination;
+- secret store and rotation ownership.
+
+Do not create target wheel/hash locks until OS/architecture are fixed.
+
+## 3. Database requirements
+
+The SQLite database is the durable source of truth for routing state, human review state, supervisor/FATWA state, Shadow observations, publication intent, and publication reconciliation.
+
+Required operating conditions:
+
+- database file lives on persistent storage;
+- SQLite WAL mode remains enabled for normal write connections;
+- filesystem must support SQLite locking semantics;
+- do not place the live database on an eventually consistent object store;
+- do not copy only the main `.db` file from a running WAL database as a backup;
+- use the SQLite backup API provided by `app.operations.database.create_verified_backup` or an equivalently validated SQLite-native snapshot procedure.
+
+### Pre-change backup
+
+Before deployment, migration, dependency/runtime change, or controlled cutover:
+
+1. verify operational readiness;
+2. create a new backup path that does not already exist;
+3. run the verified backup operation;
+4. require `integrity_check = ok` and zero foreign-key violations;
+5. store the resulting SHA-256 and backup timestamp in the change record;
+6. protect the backup using the selected retention/access policy.
+
+The backup helper refuses implicit overwrite and removes a newly created backup if verification fails.
+
+### Restore
+
+Restore is a maintenance-mode operation and must never be performed over a running writer.
+
+1. stop all Gheras write-capable processes;
+2. preserve the current database as a separate incident snapshot;
+3. validate the candidate backup with SQLite `integrity_check` and `foreign_key_check`;
+4. replace the database only through the environment-specific controlled restore procedure;
+5. start one instance in non-publishing/readiness mode first;
+6. verify counts, reconciliation holds, and Shadow state;
+7. only then proceed to the approved activation mode.
+
+A restore does not prove provider-side publication state. Any `dispatching` or `uncertain` action still requires reconciliation.
+
+## 4. Operational readiness snapshot
+
+`OperationalReadinessService` is read-only and selects counts/state only. It does not select inbound comment text, approved reply text, credentials, idempotency keys, or provider result identifiers.
+
+Review at minimum:
+
+- SQLite integrity and foreign-key violations;
+- inbound totals and failed states;
+- pending moderation human reviews;
+- supervisor pending/awaiting queues;
+- FATWA pending/awaiting queues;
+- publication pending/dispatching/uncertain/succeeded counts;
+- Shadow evaluation count.
+
+`requires_operator_attention` is true when:
+
+- SQLite integrity fails;
+- foreign-key violations exist;
+- publication actions remain `dispatching`;
+- publication actions remain `uncertain`;
+- terminal inbound failures exist.
+
+Expected human/supervisor/FATWA waiting queues are visible but are not automatically treated as database/system corruption.
+
+## 5. Publication reconciliation
+
+### Rule
+
+Never retry a `dispatching` or `uncertain` publication solely because a timeout, crash, or exception occurred. The provider may already have accepted the reply.
+
+### Inventory
+
+`OperationalReadinessService.publication_reconciliation_items()` exposes only:
+
+- internal action ID;
+- platform;
+- held status;
+- last-updated timestamp.
+
+It does not expose comment/reply text.
+
+### Provider-side verification
+
+For each held action, an authorized operator must determine one of only two outcomes using provider-side evidence:
+
+#### A. Confirmed succeeded
+
+Use only when the provider confirms the reply exists and provides a stable external result identifier.
+
+Record:
+
+- action ID;
+- operator reference;
+- evidence reference;
+- unique external reconciliation key;
+- stable external result ID.
+
+The atomic reconciliation transaction records immutable evidence and moves the action to `succeeded`. Future dispatcher calls return the durable success and do not call the provider again.
+
+#### B. Confirmed not sent
+
+Use only when provider-side evidence proves the original attempt produced no external side effect.
+
+Record:
+
+- action ID;
+- operator reference;
+- evidence reference;
+- unique external reconciliation key.
+
+The atomic reconciliation transaction records the evidence and returns the action to `pending`. This does **not** itself publish anything. A later explicit dispatcher operation may attempt publication again.
+
+### If provider outcome cannot be proven
+
+Leave the action held. Do not infer success and do not reset it to pending.
+
+## 6. Logging and redaction
+
+Production logs must be structured and content-minimized.
+
+Allowed operational fields include:
+
+- internal event/action IDs;
+- platform;
+- route/outcome/status codes;
+- adapter/client names and version identifiers;
+- retry/attempt counts;
+- timestamps and latency;
+- sanitized error codes.
+
+Do not log:
+
+- access tokens, app secrets, webhook secrets, API keys;
+- authorization headers or signed URLs;
+- full inbound comment text by default;
+- FAQ/supervisor/FATWA answer text by default;
+- provider request/response bodies containing user content;
+- raw exception objects when they may contain transport/request data.
+
+Provider errors exposed to logs/monitoring must use the existing sanitized error boundary.
+
+## 7. Monitoring and alerts
+
+The production environment should alert on state/count transitions rather than content.
+
+Recommended alert classes:
+
+- database integrity/foreign-key failure: critical;
+- any `uncertain` publication: high;
+- `dispatching` action older than the approved reconciliation threshold: high;
+- terminal inbound failure: high;
+- repeated retryable failures above threshold: medium/high;
+- supervisor/FATWA queue age above approved service target: medium;
+- webhook authentication/signature failures above baseline: medium/high;
+- provider rate-limit/authentication failures: high;
+- backup verification failure: critical.
+
+Threshold values belong to the deployment environment and must be approved before live activation.
+
+## 8. Backup retention
+
+The final retention schedule is an owner/environment decision. The selected policy must define:
+
+- backup frequency;
+- pre-deploy/pre-migration backup requirement;
+- retention periods;
+- encryption/access controls;
+- off-host or independent-failure-domain copy where appropriate;
+- periodic restore test cadence;
+- deletion procedure.
+
+Do not claim backup readiness until at least one restore rehearsal has been completed in staging using the selected production-equivalent storage/runtime.
+
+## 9. Ingress/network controls
+
+Before live registration of provider webhooks or polling:
+
+- TLS termination is defined;
+- only required public endpoints are exposed;
+- Meta webhook signature verification is enabled;
+- Telegram webhook secret validation is enabled;
+- provider verify tokens/secrets remain outside source control;
+- request-size/time limits are defined at the ingress layer;
+- rate limiting/abuse controls are configured where applicable;
+- provider callback URLs point to staging first, not production, during validation.
+
+## 10. Shadow-before-publish procedure
+
+Production-like staging must run Shadow Mode before live publication is permitted.
+
+1. use representative sandbox/staging or safely replayed traffic;
+2. keep publication disabled;
+3. collect counts for `would_publish`, `would_wait_human`, `would_route_fatwa`, `not_ready`, and `blocked`;
+4. inspect unexpected distributions and representative cases through authorized review paths;
+5. resolve unexplained routing/moderation defects;
+6. record evaluator version and dataset/time window;
+7. obtain the required activation approval only after the Shadow gate passes.
+
+## 11. Cutover procedure
+
+Cutover remains a Human Gate. When authorized:
+
+1. confirm legacy path remains retired;
+2. confirm reviewed/passed code is the exact release SHA;
+3. confirm dependency/SCA gate is current for the release;
+4. create and verify a pre-cutover database backup;
+5. confirm all required secrets/scopes through the secret store without exposing values;
+6. confirm reconciliation inventory is understood and no unexplained publication holds remain;
+7. deploy in non-publishing or Shadow mode first;
+8. validate health/readiness and provider ingress;
+9. validate supervisor/FATWA integration in the approved staging/live-safe sequence;
+10. enable publishing only after the explicit activation decision.
+
+## 12. Rollback procedure
+
+Rollback must prioritize duplicate-reply prevention over speed.
+
+1. disable new publication dispatch first;
+2. preserve the live database and logs/metrics needed for reconciliation;
+3. inventory `dispatching` and `uncertain` actions;
+4. do not retry those actions from the previous or rollback version;
+5. if code rollback is sufficient, keep the current durable database unless a schema/data rollback is specifically required and proven safe;
+6. if database restore is required, follow the maintenance-mode restore procedure and reconcile external side effects separately;
+7. resume in Shadow/non-publishing mode before re-enabling publication.
+
+## 13. Incident priorities
+
+Order of response:
+
+1. stop uncontrolled publication/side effects;
+2. protect secrets and durable evidence;
+3. preserve database state and obtain a verified snapshot;
+4. reconcile potentially duplicated/uncertain external actions;
+5. restore routing/human-review/FATWA safety invariants;
+6. only then restore normal throughput.
+
+## 14. Live activation HOLDs
+
+This runbook does not close the following by itself:
+
+- deployment target selection;
+- production secret provisioning/scopes;
+- real provider sandbox validation;
+- supervised FATWA live integration;
+- production-equivalent backup/restore rehearsal;
+- staging Shadow acceptance;
+- monitoring/alert threshold approval;
+- independent review and promotion to `main`;
+- explicit production publication activation.

--- a/scripts/ops_backup.py
+++ b/scripts/ops_backup.py
@@ -1,0 +1,43 @@
+"""Create one verified, non-overwriting SQLite backup for Gheras."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from app.operations.database import create_verified_backup
+from app.persistence.sqlite import SQLiteDatabase
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        required=True,
+        type=Path,
+        help="Existing Gheras SQLite database file",
+    )
+    parser.add_argument(
+        "--destination",
+        required=True,
+        type=Path,
+        help="New backup path; existing files are refused",
+    )
+    args = parser.parse_args()
+
+    receipt = create_verified_backup(SQLiteDatabase(args.database), args.destination)
+    payload = {
+        "created_at": receipt.created_at.isoformat(),
+        "destination": str(receipt.destination),
+        "foreign_key_violations": receipt.integrity.foreign_key_violations,
+        "integrity_ok": receipt.integrity.integrity_ok,
+        "sha256": receipt.sha256,
+        "size_bytes": receipt.size_bytes,
+    }
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops_readiness.py
+++ b/scripts/ops_readiness.py
@@ -1,0 +1,32 @@
+"""Print a content-free operational readiness snapshot for an existing SQLite database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from app.operations.readiness import OperationalReadinessService
+from app.persistence.sqlite import SQLiteDatabase
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        required=True,
+        type=Path,
+        help="Existing Gheras SQLite database file",
+    )
+    args = parser.parse_args()
+
+    snapshot = OperationalReadinessService(SQLiteDatabase(args.database)).snapshot()
+    payload = asdict(snapshot)
+    payload["requires_operator_attention"] = snapshot.requires_operator_attention
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 2 if snapshot.requires_operator_attention else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops_reconcile_publication.py
+++ b/scripts/ops_reconcile_publication.py
@@ -1,0 +1,79 @@
+"""Record one provider-verified publication reconciliation decision."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from app.persistence.reconciliation_repository import PublicationReconciliationRepository
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.reconciliation import PublicationReconciliationService
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--action-id", required=True)
+    parser.add_argument("--operator-ref", required=True)
+    parser.add_argument("--evidence-ref", required=True)
+    parser.add_argument("--reconciliation-key", required=True)
+    parser.add_argument(
+        "--provider-outcome-verified",
+        action="store_true",
+        required=True,
+        help="Required acknowledgment that provider-side outcome was independently verified",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        required=True,
+        type=Path,
+        help="Existing Gheras SQLite database file",
+    )
+    subparsers = parser.add_subparsers(dest="decision", required=True)
+
+    succeeded = subparsers.add_parser("confirmed-succeeded")
+    _add_common_arguments(succeeded)
+    succeeded.add_argument("--external-result-id", required=True)
+
+    not_sent = subparsers.add_parser("confirmed-not-sent")
+    _add_common_arguments(not_sent)
+
+    args = parser.parse_args()
+    if not args.provider_outcome_verified:
+        parser.error("provider-side outcome verification is required")
+
+    service = PublicationReconciliationService(
+        PublicationReconciliationRepository(SQLiteDatabase(args.database))
+    )
+    if args.decision == "confirmed-succeeded":
+        record, action = service.confirm_succeeded(
+            action_id=args.action_id,
+            operator_ref=args.operator_ref,
+            evidence_ref=args.evidence_ref,
+            external_reconciliation_key=args.reconciliation_key,
+            external_result_id=args.external_result_id,
+        )
+    else:
+        record, action = service.confirm_not_sent(
+            action_id=args.action_id,
+            operator_ref=args.operator_ref,
+            evidence_ref=args.evidence_ref,
+            external_reconciliation_key=args.reconciliation_key,
+        )
+
+    payload = {
+        "action_id": action.id,
+        "decision": record.decision.value,
+        "new_status": action.status,
+        "prior_status": record.prior_status.value,
+        "reconciliation_id": record.id,
+    }
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_operations_readiness.py
+++ b/tests/test_operations_readiness.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.publishing import PublicationStatus
+from app.operations.database import create_verified_backup, inspect_database
+from app.operations.readiness import OperationalReadinessService
+from app.persistence.sqlite import SQLiteDatabase
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _insert_event(database: SQLiteDatabase, *, event_id: str, text: str) -> None:
+    now = _timestamp()
+    with database.connect() as connection:
+        connection.execute(
+            """
+            INSERT INTO inbound_events (
+                id, platform, external_event_key, external_event_id,
+                external_comment_id, external_post_id, author_id, text,
+                media_json, correlation_id, status, retry_count,
+                next_retry_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                "facebook",
+                f"event-key-{event_id}",
+                f"external-{event_id}",
+                f"comment-{event_id}",
+                "post-1",
+                "author-1",
+                text,
+                None,
+                f"correlation-{event_id}",
+                "received",
+                0,
+                None,
+                now,
+                now,
+            ),
+        )
+
+
+def _insert_publication(
+    database: SQLiteDatabase,
+    *,
+    action_id: str,
+    event_id: str,
+    status: PublicationStatus,
+) -> None:
+    now = _timestamp()
+    with database.connect() as connection:
+        connection.execute(
+            """
+            INSERT INTO outbound_actions (
+                id, event_id, platform, action_type, idempotency_key,
+                status, external_result_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                action_id,
+                event_id,
+                "facebook",
+                f"reply:faq:evidence-{action_id}",
+                f"publish-key-{action_id}",
+                status.value,
+                None,
+                now,
+                now,
+            ),
+        )
+
+
+def test_readonly_connection_refuses_missing_database(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "missing.db")
+
+    with pytest.raises(FileNotFoundError):
+        database.connect_readonly()
+
+    assert not database.path.exists()
+
+
+def test_verified_backup_preserves_database_and_refuses_overwrite(tmp_path: Path) -> None:
+    database = SQLiteDatabase(tmp_path / "source.db")
+    database.initialize()
+    _insert_event(database, event_id="event-1", text="private-comment-body")
+
+    destination = tmp_path / "backups" / "snapshot.db"
+    receipt = create_verified_backup(database, destination)
+
+    assert receipt.destination == destination
+    assert receipt.size_bytes > 0
+    assert len(receipt.sha256) == 64
+    assert receipt.integrity.acceptable
+    assert inspect_database(SQLiteDatabase(destination)).acceptable
+    with SQLiteDatabase(destination).connect_readonly() as connection:
+        row = connection.execute("SELECT COUNT(*) FROM inbound_events").fetchone()
+    assert row is not None
+    assert int(row[0]) == 1
+
+    with pytest.raises(FileExistsError):
+        create_verified_backup(database, destination)
+
+
+def test_failed_backup_does_not_leave_invalid_destination(tmp_path: Path) -> None:
+    source = tmp_path / "corrupt.db"
+    source.write_bytes(b"not-a-sqlite-database")
+    destination = tmp_path / "backup.db"
+
+    with pytest.raises(Exception):
+        create_verified_backup(SQLiteDatabase(source), destination)
+
+    assert not destination.exists()
+
+
+def test_readiness_snapshot_is_counts_only_and_flags_publication_holds(
+    tmp_path: Path,
+) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    sensitive_text = "SECRET USER COMMENT MUST NOT APPEAR"
+    _insert_event(database, event_id="event-1", text=sensitive_text)
+    _insert_publication(
+        database,
+        action_id="action-dispatching",
+        event_id="event-1",
+        status=PublicationStatus.DISPATCHING,
+    )
+    _insert_publication(
+        database,
+        action_id="action-uncertain",
+        event_id="event-1",
+        status=PublicationStatus.UNCERTAIN,
+    )
+
+    snapshot = OperationalReadinessService(database).snapshot()
+
+    assert snapshot.integrity.acceptable
+    assert snapshot.inbound_total == 1
+    assert snapshot.publications_dispatching == 1
+    assert snapshot.publications_uncertain == 1
+    assert snapshot.requires_operator_attention
+    assert sensitive_text not in repr(snapshot)
+
+
+def test_reconciliation_inventory_exposes_only_opaque_operational_fields(
+    tmp_path: Path,
+) -> None:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    sensitive_text = "do-not-surface-this-comment"
+    _insert_event(database, event_id="event-1", text=sensitive_text)
+    _insert_publication(
+        database,
+        action_id="action-pending",
+        event_id="event-1",
+        status=PublicationStatus.PENDING,
+    )
+    _insert_publication(
+        database,
+        action_id="action-uncertain",
+        event_id="event-1",
+        status=PublicationStatus.UNCERTAIN,
+    )
+
+    items = OperationalReadinessService(database).publication_reconciliation_items()
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.action_id == "action-uncertain"
+    assert item.status is PublicationStatus.UNCERTAIN
+    assert set(asdict(item)) == {"action_id", "platform", "status", "updated_at"}
+    assert sensitive_text not in repr(item)

--- a/tests/test_operations_readiness.py
+++ b/tests/test_operations_readiness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -114,7 +115,7 @@ def test_failed_backup_does_not_leave_invalid_destination(tmp_path: Path) -> Non
     source.write_bytes(b"not-a-sqlite-database")
     destination = tmp_path / "backup.db"
 
-    with pytest.raises(Exception):
+    with pytest.raises(sqlite3.DatabaseError):
         create_verified_backup(SQLiteDatabase(source), destination)
 
     assert not destination.exists()

--- a/tests/test_publication_reconciliation.py
+++ b/tests/test_publication_reconciliation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.domain.publishing import PublicationStatus
+from app.domain.reconciliation import PublicationReconciliationDecision
+from app.persistence.reconciliation_repository import PublicationReconciliationRepository
+from app.persistence.repositories import IdempotencyConflict
+from app.persistence.sqlite import SQLiteDatabase
+from app.services.reconciliation import PublicationReconciliationService
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _setup_action(
+    tmp_path: Path,
+    *,
+    status: PublicationStatus,
+) -> tuple[SQLiteDatabase, str]:
+    database = SQLiteDatabase(tmp_path / "router.db")
+    database.initialize()
+    now = _timestamp()
+    event_id = "event-1"
+    action_id = "action-1"
+    with database.connect() as connection:
+        connection.execute(
+            """
+            INSERT INTO inbound_events (
+                id, platform, external_event_key, external_event_id,
+                external_comment_id, external_post_id, author_id, text,
+                media_json, correlation_id, status, retry_count,
+                next_retry_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                "facebook",
+                "event-key-1",
+                "external-event-1",
+                "comment-1",
+                "post-1",
+                "author-1",
+                "sensitive body",
+                None,
+                "correlation-1",
+                "received",
+                0,
+                None,
+                now,
+                now,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO outbound_actions (
+                id, event_id, platform, action_type, idempotency_key,
+                status, external_result_id, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                action_id,
+                event_id,
+                "facebook",
+                "reply:faq:evidence-1",
+                "publish-key-1",
+                status.value,
+                None,
+                now,
+                now,
+            ),
+        )
+    return database, action_id
+
+
+def test_confirmed_success_closes_uncertain_action(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.UNCERTAIN)
+    service = PublicationReconciliationService(PublicationReconciliationRepository(database))
+
+    record, action = service.confirm_succeeded(
+        action_id=action_id,
+        operator_ref="operator-7",
+        evidence_ref="provider-case-42",
+        external_reconciliation_key="reconcile-1",
+        external_result_id="provider-result-99",
+    )
+
+    assert record.prior_status is PublicationStatus.UNCERTAIN
+    assert record.decision is PublicationReconciliationDecision.CONFIRMED_SUCCEEDED
+    assert action.status == PublicationStatus.SUCCEEDED.value
+    assert action.external_result_id == "provider-result-99"
+
+
+def test_confirmed_not_sent_returns_dispatching_action_to_pending(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.DISPATCHING)
+    service = PublicationReconciliationService(PublicationReconciliationRepository(database))
+
+    record, action = service.confirm_not_sent(
+        action_id=action_id,
+        operator_ref="operator-7",
+        evidence_ref="provider-search-no-match",
+        external_reconciliation_key="reconcile-2",
+    )
+
+    assert record.prior_status is PublicationStatus.DISPATCHING
+    assert record.decision is PublicationReconciliationDecision.CONFIRMED_NOT_SENT
+    assert action.status == PublicationStatus.PENDING.value
+    assert action.external_result_id is None
+
+
+def test_reconciliation_is_idempotent_for_same_external_key(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.UNCERTAIN)
+    service = PublicationReconciliationService(PublicationReconciliationRepository(database))
+    arguments = {
+        "action_id": action_id,
+        "operator_ref": "operator-7",
+        "evidence_ref": "provider-case-42",
+        "external_reconciliation_key": "reconcile-3",
+        "external_result_id": "provider-result-100",
+    }
+
+    first_record, first_action = service.confirm_succeeded(**arguments)
+    second_record, second_action = service.confirm_succeeded(**arguments)
+
+    assert second_record == first_record
+    assert second_action == first_action
+
+
+def test_reconciliation_key_conflict_is_rejected(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.UNCERTAIN)
+    service = PublicationReconciliationService(PublicationReconciliationRepository(database))
+    service.confirm_succeeded(
+        action_id=action_id,
+        operator_ref="operator-7",
+        evidence_ref="provider-case-42",
+        external_reconciliation_key="reconcile-4",
+        external_result_id="provider-result-101",
+    )
+
+    with pytest.raises(IdempotencyConflict):
+        service.confirm_succeeded(
+            action_id=action_id,
+            operator_ref="operator-8",
+            evidence_ref="different-evidence",
+            external_reconciliation_key="reconcile-4",
+            external_result_id="provider-result-102",
+        )
+
+
+def test_pending_or_succeeded_actions_cannot_be_reconciled(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.PENDING)
+    service = PublicationReconciliationService(PublicationReconciliationRepository(database))
+
+    with pytest.raises(ValueError, match="dispatching or uncertain"):
+        service.confirm_not_sent(
+            action_id=action_id,
+            operator_ref="operator-7",
+            evidence_ref="provider-no-match",
+            external_reconciliation_key="reconcile-5",
+        )
+
+
+def test_confirmed_success_requires_provider_result_id(tmp_path: Path) -> None:
+    database, action_id = _setup_action(tmp_path, status=PublicationStatus.UNCERTAIN)
+    repository = PublicationReconciliationRepository(database)
+
+    with pytest.raises(ValueError, match="requires external_result_id"):
+        repository.reconcile(
+            action_id=action_id,
+            decision=PublicationReconciliationDecision.CONFIRMED_SUCCEEDED,
+            operator_ref="operator-7",
+            evidence_ref="provider-case-42",
+            external_reconciliation_key="reconcile-6",
+        )


### PR DESCRIPTION
## Summary

Phase 18 closes the non-live production-operations preparation layer above the locked Phase 17 supply-chain gate. It does not deploy Gheras, provision credentials, register provider webhooks, call external providers, or authorize production publishing.

### Operational readiness
- read-only SQLite connection that refuses missing databases
- counts-only `OperationalReadinessService`
- no inbound/reply content, credentials, idempotency keys, or provider result IDs selected by readiness snapshots
- explicit operator-attention signal for integrity failures, terminal failures, and held publication states

### Verified SQLite backup
- SQLite-native backup API
- missing source refused
- existing destination refused; no implicit overwrite
- integrity + foreign-key verification after backup
- invalid newly created backup removed on verification failure
- successful receipt includes SHA-256, size, and timestamp

### Durable publication reconciliation
- content-free inventory for `dispatching` / `uncertain` holds
- immutable `publication_reconciliations` evidence ledger
- provider-confirmed `succeeded` requires stable external result ID
- provider-confirmed `not sent` restores only `pending`; reconciliation itself never publishes
- reconciliation and outbound state change are atomic under `BEGIN IMMEDIATE`
- external reconciliation keys are idempotent; conflicting semantics are rejected
- no blind retry when provider outcome is unresolved

### Operational tooling and documentation
- `scripts/ops_readiness.py`
- `scripts/ops_backup.py`
- guarded `scripts/ops_reconcile_publication.py`
- `docs/PRODUCTION_OPERATIONS_RUNBOOK.md`
- `docs/PRODUCTION_ACTIVATION_CHECKLIST.md`
- `docs/HUMAN_GATES.md` updates HG-10 to engineering-preparation PASS / environment-specific activation HOLD
- lock evidence: `docs/PHASE18_PRODUCTION_OPERATIONS_LOCK.md`

### Final validation
Final GitHub Actions run `34607596707` on head `263fe8f9ca8a7a7b7736f11ef6a7085098fc4fb6`:
- production lock metadata PASS
- dependency consistency PASS
- production dependency audit PASS
- build-tool audit PASS
- CI/development audit PASS
- production environment reproduction PASS
- Ruff PASS
- Mypy PASS
- Pytest PASS

### Adversarial scope review
Phase 17 → Phase 18 changes are limited to local SQLite operations, durable reconciliation, tests, local operational scripts, and documentation. No provider network call, credential, webhook registration, deployment, or live publishing path is introduced.

### Remaining HOLDs
- independent submitted review of the stacked implementation chain
- reviewed promotion to `main`
- production OS/architecture and target artifact/hash verification
- persistent volume/filesystem and process topology selection
- approved secret store and production credentials/scopes
- real Facebook/Instagram/Telegram/YouTube sandbox validation
- supervised FATWA live integration
- production-equivalent backup/restore rehearsal
- monitoring destinations/thresholds and TLS/public ingress decisions
- representative staging Shadow acceptance
- explicit production publication activation

No secret, credential, external provider call, webhook registration, OAuth exchange, deployment, AI-generated FATWA, or production publication is introduced.